### PR TITLE
[codex] Ignore private agent overlay symlinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,9 +50,9 @@ yarn-error.log*
 !packages/context/test/fixtures/relationship-benchmarks/**/data.sqlite
 
 # Private local agent overlays
-.agents/
-.claude/
-.superpowers/
+.agents
+.claude
+.superpowers
 
 # Editors and OS files
 .idea/


### PR DESCRIPTION
## Summary

Update the private local agent overlay ignore rules so `.agents`, `.claude`, and `.superpowers` are ignored whether they are directories or symlinks. This prevents Conductor-linked local skill overlays from appearing as untracked files after workspace setup.

## Verification

Ran `git check-ignore -v .agents .claude .superpowers` and reviewed `git diff origin/main...`.
