### PR TITLE
Mirror .agents/skills into .claude/skills so Claude Code sees overlay skills

### DIFF
--- a/scripts/conductor-setup.sh
+++ b/scripts/conductor-setup.sh
@@ -99,9 +99,46 @@ link_agent_overlays() {
   ln -s "${KTX_AGENT_OVERLAYS_ROOT}/.agents" .agents
 }
 
+# Expose .agents/skills/* to Claude Code by symlinking each entry under
+# .claude/skills/. Codex CLI reads .agents/skills/ directly; Claude Code only
+# scans .claude/skills/, so the overlay needs both sides to be visible to both
+# tools.
+link_agent_skills_for_claude() {
+  if [ ! -d .agents/skills ]; then
+    return 0
+  fi
+
+  mkdir -p .claude/skills
+
+  for skill_path in .agents/skills/*; do
+    [ -e "$skill_path" ] || continue
+
+    local skill_name
+    skill_name="$(basename "$skill_path")"
+    local link_path=".claude/skills/$skill_name"
+    local target="../../.agents/skills/$skill_name"
+
+    if [ -L "$link_path" ]; then
+      if [ "$(readlink "$link_path")" = "$target" ]; then
+        continue
+      fi
+      echo "Skipping $link_path: existing symlink points elsewhere." >&2
+      continue
+    fi
+
+    if [ -e "$link_path" ]; then
+      echo "Skipping $link_path: already exists and is not a symlink." >&2
+      continue
+    fi
+
+    ln -s "$target" "$link_path"
+  done
+}
+
 echo "=== Conductor KTX workspace setup ==="
 
 link_agent_overlays
+link_agent_skills_for_claude
 
 if [ -n "${CONDUCTOR_ROOT_PATH:-}" ] && [ -f "$CONDUCTOR_ROOT_PATH/.env" ]; then
   ln -sf "$CONDUCTOR_ROOT_PATH/.env" .env


### PR DESCRIPTION
## Summary
- Codex CLI reads `.agents/skills/` directly, but Claude Code only scans `.claude/skills/`, so skills exposed by the Conductor agent overlay (e.g. `codex-coder-light`) were invisible to Claude.
- Extend `scripts/conductor-setup.sh` with `link_agent_skills_for_claude`, which mirrors each `.agents/skills/*` entry as a symlink under `.claude/skills/*` (`../../.agents/skills/<name>`) after `link_agent_overlays` runs. The function is idempotent and refuses to clobber non-matching pre-existing entries.

## Test plan
- [ ] Fresh Conductor workspace with `KTX_AGENT_OVERLAYS_ROOT` set: `.claude/skills/` is populated with one symlink per `.agents/skills/*` entry, all resolving correctly.
- [ ] Re-running `scripts/conductor-setup.sh` produces no new symlinks and no errors.
- [ ] In a workspace where `.claude/skills/<name>` already exists as a real dir or stale symlink, the script logs a skip and leaves it untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)