### PR TITLE
fix(cli): retry daemon health before startup failure

### DIFF
--- a/packages/cli/src/managed-python-daemon.test.ts
+++ b/packages/cli/src/managed-python-daemon.test.ts
@@ -170,6 +170,41 @@ describe('managed Python daemon lifecycle', () => {
     });
   });
 
+  it('makes a final health probe before reporting startup failure', async () => {
+    const spawnDaemon = makeSpawn(5556);
+    const installRuntime = vi.fn(async () => installResult(tempDir));
+    const fetch = vi
+      .fn<ManagedPythonDaemonFetch>()
+      .mockRejectedValueOnce(new Error('fetch failed'))
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ status: 'healthy', version: '0.2.0' }),
+        text: async () => '',
+      });
+
+    const result = await startManagedPythonDaemon({
+      cliVersion: '0.2.0',
+      runtimeRoot: join(tempDir, 'runtime'),
+      features: ['core'],
+      installRuntime,
+      spawnDaemon,
+      fetch,
+      allocatePort: vi.fn(async () => 61234),
+      now: () => new Date('2026-05-11T00:00:00.000Z'),
+      startupTimeoutMs: 5,
+      pollIntervalMs: 20,
+    });
+
+    expect(result.status).toBe('started');
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(JSON.parse(await readFile(layout(tempDir).daemonStatePath, 'utf8'))).toMatchObject({
+      pid: 5556,
+      port: 61234,
+      version: '0.2.0',
+    });
+  });
+
   it('reuses a healthy daemon with the requested feature set', async () => {
     await mkdir(layout(tempDir).versionDir, { recursive: true });
     await writeFile(layout(tempDir).daemonStatePath, `${JSON.stringify(runningState(tempDir), null, 2)}\n`);

--- a/packages/cli/src/managed-python-daemon.ts
+++ b/packages/cli/src/managed-python-daemon.ts
@@ -273,6 +273,15 @@ async function waitForHealth(input: {
     lastDetail = health.detail;
     await delay(input.pollIntervalMs);
   }
+  const finalHealth = await healthOk({
+    state: input.state,
+    cliVersion: input.cliVersion,
+    fetch: input.fetch,
+  });
+  if (finalHealth.ok) {
+    return;
+  }
+  lastDetail = finalHealth.detail;
   throw new Error(`KTX Python daemon failed to start: ${lastDetail}. stderr: ${input.state.stderrLog}`);
 }
 


### PR DESCRIPTION
## Summary
Fixes managed Python daemon startup at the timeout edge by making one final `/health` probe before throwing a startup failure.
Adds regression coverage for an initial `fetch failed` followed by a healthy daemon response so successful late startups write daemon state.

## Tests
- `pnpm --filter @ktx/cli exec vitest run src/managed-python-daemon.test.ts`
- `pnpm --filter @ktx/cli run type-check`
- `pnpm --filter @ktx/cli run test`