### PR TITLE
fix(cli): support Metabase connection tests

### DIFF
--- a/packages/cli/src/connection.test.ts
+++ b/packages/cli/src/connection.test.ts
@@ -1,7 +1,8 @@
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { initKtxProject, parseKtxProjectConfig } from '@ktx/context/project';
+import type { MetabaseRuntimeClient } from '@ktx/context/ingest';
+import { initKtxProject, parseKtxProjectConfig, serializeKtxProjectConfig } from '@ktx/context/project';
 import type { KtxConnectionDriver, KtxScanConnector, KtxSchemaSnapshot } from '@ktx/context/scan';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { runKtxConnection } from './connection.js';
@@ -596,6 +597,61 @@ describe('runKtxConnection', () => {
     expect(io.stdout()).toContain('Connection test passed: warehouse');
     expect(io.stdout()).toContain('Driver: sqlite');
     expect(io.stdout()).toContain('Tables: 2');
+  });
+
+  it('tests a configured Metabase connection through the Metabase runtime client', async () => {
+    const projectDir = join(tempDir, 'project');
+    await initKtxProject({ projectDir, projectName: 'warehouse' });
+    const projectConfig = parseKtxProjectConfig(await readFile(join(projectDir, 'ktx.yaml'), 'utf-8'));
+    await writeFile(
+      join(projectDir, 'ktx.yaml'),
+      serializeKtxProjectConfig({
+        ...projectConfig,
+        connections: {
+          ...projectConfig.connections,
+          prod_metabase: {
+            driver: 'metabase',
+            api_url: 'http://metabase.example.test',
+            api_key: 'mb_test',
+          },
+        },
+      }),
+      'utf-8',
+    );
+    const testConnection = vi.fn(async () => ({ success: true as const }));
+    const getDatabases = vi.fn(async () => [
+      { id: 1, name: 'Analytics', engine: 'postgres', details: {}, is_sample: false },
+      { id: 2, name: 'Sample Database', engine: 'h2', details: {}, is_sample: true },
+    ]);
+    const cleanup = vi.fn(async () => undefined);
+    const createMetabaseClient = vi.fn(
+      async (): Promise<Pick<MetabaseRuntimeClient, 'testConnection' | 'getDatabases' | 'cleanup'>> => ({
+        testConnection,
+        getDatabases,
+        cleanup,
+      }),
+    );
+    const createScanConnector = vi.fn(async () => {
+      throw new Error('native scanner should not be used for Metabase');
+    });
+    const io = makeIo();
+
+    await expect(
+      runKtxConnection({ command: 'test', projectDir, connectionId: 'prod_metabase' }, io.io, {
+        createScanConnector,
+        createMetabaseClient,
+      }),
+    ).resolves.toBe(0);
+
+    expect(createScanConnector).not.toHaveBeenCalled();
+    expect(createMetabaseClient).toHaveBeenCalledWith(expect.objectContaining({ projectDir }), 'prod_metabase');
+    expect(testConnection).toHaveBeenCalledTimes(1);
+    expect(getDatabases).toHaveBeenCalledTimes(1);
+    expect(cleanup).toHaveBeenCalledTimes(1);
+    expect(io.stdout()).toContain('Connection test passed: prod_metabase');
+    expect(io.stdout()).toContain('Driver: metabase');
+    expect(io.stdout()).toContain('Databases: 1');
+    expect(io.stderr()).toBe('');
   });
 
   it('cleans up the native scan connector when connection testing fails', async () => {

--- a/packages/cli/src/connection.ts
+++ b/packages/cli/src/connection.ts
@@ -1,4 +1,10 @@
 import { cancel, confirm, isCancel } from '@clack/prompts';
+import {
+  DEFAULT_METABASE_CLIENT_CONFIG,
+  DefaultMetabaseConnectionClientFactory,
+  type MetabaseRuntimeClient,
+  metabaseRuntimeConfigFromLocalConnection,
+} from '@ktx/context/ingest';
 import { type KtxLocalProject, loadKtxProject, serializeKtxProjectConfig } from '@ktx/context/project';
 import type { KtxScanConnector } from '@ktx/context/scan';
 import type { KtxConnectionMappingArgs } from './commands/connection-mapping.js';
@@ -61,6 +67,7 @@ interface KtxConnectionIo extends KtxCliIo {
 
 interface KtxConnectionDeps {
   createScanConnector?: typeof createKtxCliScanConnector;
+  createMetabaseClient?: typeof createDefaultMetabaseClient;
   runMapping?: (argv: string[], io: KtxCliIo) => Promise<number>;
   prompts?: KtxConnectionPromptAdapter;
 }
@@ -104,6 +111,12 @@ async function cleanupConnector(connector: KtxScanConnector | null): Promise<voi
   }
 }
 
+function normalizedConnectionDriver(project: KtxLocalProject, connectionId: string): string {
+  return String(project.config.connections[connectionId]?.driver ?? '')
+    .trim()
+    .toLowerCase();
+}
+
 async function testNativeConnection(
   project: KtxLocalProject,
   connectionId: string,
@@ -128,6 +141,48 @@ async function testNativeConnection(
     };
   } finally {
     await cleanupConnector(connector);
+  }
+}
+
+async function createDefaultMetabaseClient(
+  project: KtxLocalProject,
+  connectionId: string,
+): Promise<Pick<MetabaseRuntimeClient, 'testConnection' | 'getDatabases' | 'cleanup'>> {
+  const factory = new DefaultMetabaseConnectionClientFactory(
+    (metabaseConnectionId) =>
+      metabaseRuntimeConfigFromLocalConnection(
+        metabaseConnectionId,
+        project.config.connections[metabaseConnectionId],
+      ),
+    DEFAULT_METABASE_CLIENT_CONFIG,
+  );
+  return factory.createClient(connectionId);
+}
+
+async function testMetabaseConnection(
+  project: KtxLocalProject,
+  connectionId: string,
+  createMetabaseClient: typeof createDefaultMetabaseClient,
+): Promise<{ driver: 'metabase'; databaseCount: number }> {
+  let client: Pick<MetabaseRuntimeClient, 'testConnection' | 'getDatabases' | 'cleanup'> | null = null;
+  try {
+    client = await createMetabaseClient(project, connectionId);
+    const testResult = await client.testConnection();
+    if (!testResult.success) {
+      throw new Error(
+        `Metabase connection test failed: ${testResult.error ?? testResult.message ?? 'unknown error'}`,
+      );
+    }
+
+    const databases = await client.getDatabases();
+    const databaseCount = databases.filter((database) => database.is_sample !== true).length;
+    if (databaseCount === 0) {
+      throw new Error('Metabase auth worked but no usable databases were returned');
+    }
+
+    return { driver: 'metabase', databaseCount };
+  } finally {
+    await client?.cleanup();
   }
 }
 
@@ -396,6 +451,18 @@ export async function runKtxConnection(
       );
       io.stdout.write('Connection removed from ktx.yaml.\n');
       io.stdout.write('Ingested artifacts from this connection remain in .ktx/. Run ktx dev artifacts to inspect.\n');
+      return 0;
+    }
+
+    if (normalizedConnectionDriver(project, args.connectionId) === 'metabase') {
+      const result = await testMetabaseConnection(
+        project,
+        args.connectionId,
+        deps.createMetabaseClient ?? createDefaultMetabaseClient,
+      );
+      io.stdout.write(`Connection test passed: ${args.connectionId}\n`);
+      io.stdout.write(`Driver: ${result.driver}\n`);
+      io.stdout.write(`Databases: ${result.databaseCount}\n`);
       return 0;
     }
 


### PR DESCRIPTION
## Summary

- Adds a Metabase-specific `ktx connection test` path that uses the saved Metabase runtime client instead of the native scan connector.
- Reports the non-sample Metabase database count after authentication and discovery succeed.
- Adds CLI regression coverage for `driver: metabase`.

## Verification

- `pnpm --filter @ktx/cli exec vitest run src/connection.test.ts`
- `pnpm --filter @ktx/cli run type-check`
- `git diff --check`
