### PR TITLE
ci: parallelize KTX CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,19 +15,20 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  check:
+  typescript-checks:
+    name: TypeScript checks
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
+        uses: pnpm/action-setup@739bfe42ca9233c5e6aca07c1a25a9d34aca49b0 # v6.0.7
         with:
           run_install: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24"
           cache: "pnpm"
@@ -39,11 +40,93 @@ jobs:
       - name: Run TypeScript checks
         run: pnpm run check
 
-      - name: Run slow TypeScript tests
-        run: pnpm run test:slow
+  slow-context-tests:
+    name: Slow context tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@739bfe42ca9233c5e6aca07c1a25a9d34aca49b0 # v6.0.7
+        with:
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
+          cache: "pnpm"
+          cache-dependency-path: "pnpm-lock.yaml"
+
+      - name: Install TypeScript dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build TypeScript packages
+        run: pnpm run build
+
+      - name: Run slow context tests
+        run: pnpm --filter @ktx/context run test:slow
+
+  slow-cli-tests:
+    name: Slow CLI tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@739bfe42ca9233c5e6aca07c1a25a9d34aca49b0 # v6.0.7
+        with:
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
+          cache: "pnpm"
+          cache-dependency-path: "pnpm-lock.yaml"
+
+      - name: Install TypeScript dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build TypeScript packages
+        run: pnpm run build
+
+      - name: Run slow CLI tests
+        run: pnpm --filter @ktx/cli run test:slow
+
+  cli-smoke-tests:
+    name: CLI smoke tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@739bfe42ca9233c5e6aca07c1a25a9d34aca49b0 # v6.0.7
+        with:
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
+          cache: "pnpm"
+          cache-dependency-path: "pnpm-lock.yaml"
+
+      - name: Install TypeScript dependencies
+        run: pnpm install --frozen-lockfile
 
       - name: Run CLI smoke tests
         run: pnpm run smoke
+
+  python-checks:
+    name: Python checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -51,7 +134,7 @@ jobs:
           python-version: "3.13"
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
@@ -62,11 +145,47 @@ jobs:
       - name: Run Python checks
         run: uv run pytest
 
+  artifact-checks:
+    name: Artifact checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@739bfe42ca9233c5e6aca07c1a25a9d34aca49b0 # v6.0.7
+        with:
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
+          cache: "pnpm"
+          cache-dependency-path: "pnpm-lock.yaml"
+
+      - name: Install TypeScript dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.13"
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install Python dependencies
+        run: uv sync --all-packages
+
       - name: Build and verify package artifacts
         run: pnpm run artifacts:check
 
       - name: Upload package artifacts
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ktx-package-artifacts-${{ github.sha }}
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,12 +24,12 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
+        uses: pnpm/action-setup@739bfe42ca9233c5e6aca07c1a25a9d34aca49b0 # v6.0.7
         with:
           run_install: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24"
           cache: "pnpm"
@@ -44,7 +44,7 @@ jobs:
           python-version: "3.13"
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"

--- a/scripts/ci-artifact-upload.test.mjs
+++ b/scripts/ci-artifact-upload.test.mjs
@@ -31,7 +31,7 @@ describe('KTX CI artifact upload contract', () => {
       workflow,
       /name: Build and verify package artifacts\s+run: pnpm run artifacts:check\s+- name: Upload package artifacts/s,
     );
-    assert.match(workflow, /uses: actions\/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f/);
+    assert.match(workflow, /uses: actions\/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a/);
     assert.match(workflow, /name: ktx-package-artifacts-\$\{\{ github\.sha \}\}/);
     assert.match(workflow, /dist\/artifacts\/manifest\.json/);
     assert.match(workflow, /dist\/artifacts\/npm\/\*\.tgz/);

--- a/scripts/standalone-ci-workflow.test.mjs
+++ b/scripts/standalone-ci-workflow.test.mjs
@@ -13,25 +13,39 @@ function assertIncludesAll(text, values) {
 }
 
 describe('standalone KTX CI workflow', () => {
-  it('runs the package checks from a filtered repository root', async () => {
+  it('runs package checks in parallel jobs from the repository root', async () => {
     const workflow = await readText('.github/workflows/ci.yml');
 
     assert.match(workflow, /^name: KTX CI/m);
     assertIncludesAll(workflow, [
       'permissions:',
       'contents: read',
+      'typescript-checks:',
+      'name: TypeScript checks',
+      'slow-context-tests:',
+      'name: Slow context tests',
+      'slow-cli-tests:',
+      'name: Slow CLI tests',
+      'cli-smoke-tests:',
+      'name: CLI smoke tests',
+      'python-checks:',
+      'name: Python checks',
+      'artifact-checks:',
+      'name: Artifact checks',
       'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd',
-      'pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061',
-      'actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238',
+      'pnpm/action-setup@739bfe42ca9233c5e6aca07c1a25a9d34aca49b0',
+      'actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e',
       'node-version: "24"',
       'cache-dependency-path: "pnpm-lock.yaml"',
       'pnpm install --frozen-lockfile',
       'pnpm run check',
-      'pnpm run test:slow',
+      'pnpm run build',
+      'pnpm --filter @ktx/context run test:slow',
+      'pnpm --filter @ktx/cli run test:slow',
       'pnpm run smoke',
       'actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405',
       'python-version: "3.13"',
-      'astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b',
+      'astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b',
       'cache-dependency-glob: "uv.lock"',
       'uv sync --all-packages',
       'uv run pytest',
@@ -42,13 +56,14 @@ describe('standalone KTX CI workflow', () => {
     assert.doesNotMatch(workflow, /cd ktx/);
     assert.doesNotMatch(workflow, /ktx\/pnpm-lock\.yaml/);
     assert.doesNotMatch(workflow, /ktx\/uv\.lock/);
+    assert.doesNotMatch(workflow, /run: pnpm run test:slow/);
   });
 
   it('uploads verified artifacts from root-relative paths', async () => {
     const workflow = await readText('.github/workflows/ci.yml');
 
     assertIncludesAll(workflow, [
-      'actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f',
+      'actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a',
       'name: ktx-package-artifacts-${{ github.sha }}',
       'dist/artifacts/manifest.json',
       'dist/artifacts/npm/*.tgz',


### PR DESCRIPTION
## Summary
- Split the KTX CI workflow into parallel TypeScript, slow context, slow CLI, CLI smoke, Python, and artifact jobs.
- Update CI and release workflow action pins together.
- Refresh workflow contract tests for the new CI topology and artifact upload pin.

## Verification
- node --test scripts/standalone-ci-workflow.test.mjs scripts/test-tiering.test.mjs scripts/ci-artifact-upload.test.mjs scripts/release-workflow.test.mjs
- ruby -e "require 'psych'; Psych.parse_file('.github/workflows/ci.yml'); Psych.parse_file('.github/workflows/release.yml'); puts 'workflow yaml parsed'"