### PR TITLE
fix(cli): scale nested scan progress phases

### DIFF
--- a/packages/cli/src/scan.test.ts
+++ b/packages/cli/src/scan.test.ts
@@ -573,6 +573,32 @@ describe('runKtxScan', () => {
     expect(io.stdout()).toContain('\n[90%] Building embeddings 1/4 batches\n');
   });
 
+  it('scales nested progress phases by the parent phase weight', async () => {
+    const io = makeIo({ isTTY: true });
+    const previousCi = process.env.CI;
+    delete process.env.CI;
+
+    try {
+      const progress = createCliScanProgress(io.io);
+      await progress.update(0.82, 'Enriching schema metadata');
+      const enrichmentProgress = progress.startPhase(0.18);
+      await enrichmentProgress.update(0.05, 'Loaded schema snapshot with 56 tables');
+      const descriptionProgress = enrichmentProgress.startPhase(0.45);
+      await descriptionProgress.update(37 / 56, 'Generating descriptions 37/56 tables', { transient: true });
+      await descriptionProgress.update(1, 'Generated descriptions for 56 tables');
+    } finally {
+      if (previousCi === undefined) {
+        delete process.env.CI;
+      } else {
+        process.env.CI = previousCi;
+      }
+    }
+
+    expect(io.stdout()).toContain('\r[88%] Generating descriptions 37/56 tables');
+    expect(io.stdout()).toContain('\n[91%] Generated descriptions for 56 tables\n');
+    expect(io.stdout()).not.toContain('[100%] Generating descriptions 37/56 tables');
+  });
+
   it('flushes transient TTY progress messages before printing scan failures', async () => {
     await initKtxProject({ projectDir: tempDir, projectName: 'warehouse' });
     const runLocalScan = vi.fn(async (input: RunLocalScanOptions): Promise<LocalScanRunResult> => {

--- a/packages/cli/src/scan.ts
+++ b/packages/cli/src/scan.ts
@@ -527,7 +527,7 @@ export function createCliScanProgress(
       io.stdout.write(`${line}\n`);
     },
     startPhase(phaseWeight: number) {
-      return createCliScanProgress(io, state, state.progress, phaseWeight);
+      return createCliScanProgress(io, state, state.progress, weight * phaseWeight);
     },
     flush() {
       if (!shouldWrite || !state.hasPendingTransient) {


### PR DESCRIPTION
Fixes KLO-644 by scaling nested scan progress phases by their parent phase weight.

The root cause was that child phases used their own weight as absolute progress, so description generation inside the 82%-100% enrichment window could render as 100% before finishing.

This keeps enriched scan progress honest and adds a regression for the 37/56 tables case.

Validation: `pnpm --filter @ktx/cli exec vitest run src/scan.test.ts`, `pnpm --filter @ktx/cli run type-check`, and `pnpm --filter @ktx/cli run test`.