### PR TITLE
feat(cli): improve database setup UX

### DIFF
--- a/packages/cli/src/setup-databases.test.ts
+++ b/packages/cli/src/setup-databases.test.ts
@@ -142,8 +142,8 @@ describe('setup databases step', () => {
     expect(prompts.select).toHaveBeenCalledWith({
       message: 'How do you want to connect to PostgreSQL?',
       options: [
-        { value: 'fields', label: 'Enter connection details (host, port, database, user)' },
         { value: 'url', label: 'Paste a connection URL' },
+        { value: 'fields', label: 'Enter connection details (host, port, database, user)' },
         { value: 'back', label: 'Back' },
       ],
     });
@@ -152,6 +152,43 @@ describe('setup databases step', () => {
       'Which primary sources should KTX connect to?\n' +
         'Use Up/Down to move, Space to select or unselect, Enter to confirm, Escape to go back, or Ctrl+C to exit.',
     );
+  });
+
+  it('offers connection URL paste first for URL-capable primary sources', async () => {
+    const cases: Array<{ driver: KtxSetupDatabaseDriver; label: string }> = [
+      { driver: 'postgres', label: 'PostgreSQL' },
+      { driver: 'mysql', label: 'MySQL' },
+      { driver: 'clickhouse', label: 'ClickHouse' },
+      { driver: 'sqlserver', label: 'SQL Server' },
+    ];
+
+    for (const testCase of cases) {
+      const prompts = makePromptAdapter({
+        selectValues: ['back'],
+      });
+
+      const result = await runKtxSetupDatabasesStep(
+        {
+          projectDir: tempDir,
+          inputMode: 'auto',
+          databaseDrivers: [testCase.driver],
+          skipDatabases: false,
+          databaseSchemas: [],
+        },
+        makeIo().io,
+        { prompts },
+      );
+
+      expect(result.status).toBe('back');
+      expect(prompts.select).toHaveBeenCalledWith({
+        message: `How do you want to connect to ${testCase.label}?`,
+        options: [
+          { value: 'url', label: 'Paste a connection URL' },
+          { value: 'fields', label: 'Enter connection details (host, port, database, user)' },
+          { value: 'back', label: 'Back' },
+        ],
+      });
+    }
   });
 
   it('lets Back leave database setup when the driver came from flags', async () => {
@@ -488,8 +525,8 @@ describe('setup databases step', () => {
     expect(prompts.select).toHaveBeenNthCalledWith(1, {
       message: 'How do you want to connect to PostgreSQL?',
       options: [
-        { value: 'fields', label: 'Enter connection details (host, port, database, user)' },
         { value: 'url', label: 'Paste a connection URL' },
+        { value: 'fields', label: 'Enter connection details (host, port, database, user)' },
         { value: 'back', label: 'Back' },
       ],
     });

--- a/packages/cli/src/setup-databases.test.ts
+++ b/packages/cli/src/setup-databases.test.ts
@@ -955,10 +955,11 @@ describe('setup databases step', () => {
       [
         '◇  Testing postgres-warehouse',
         '│  ✓ Connection test passed',
-        '│  Driver: PostgreSQL · Tables: 2',
+        '│  Driver: PostgreSQL',
         '│',
       ].join('\n'),
     );
+    expect(io.stdout()).not.toContain('Tables: 2');
     expect(io.stdout()).toContain(
       [
         '◇  Scanning postgres-warehouse',

--- a/packages/cli/src/setup-databases.ts
+++ b/packages/cli/src/setup-databases.ts
@@ -615,8 +615,8 @@ async function buildUrlConnectionConfig(input: {
     const choice = await input.prompts.select({
       message: `How do you want to connect to ${label}?`,
       options: [
-        { value: 'fields', label: 'Enter connection details (host, port, database, user)' },
         { value: 'url', label: 'Paste a connection URL' },
+        { value: 'fields', label: 'Enter connection details (host, port, database, user)' },
         { value: 'back', label: 'Back' },
       ],
     });

--- a/packages/cli/src/setup-databases.ts
+++ b/packages/cli/src/setup-databases.ts
@@ -1184,9 +1184,7 @@ async function validateAndScanConnection(input: {
   const testOutput = testIo.stdoutText();
   const outputDriver = normalizeDriver(readOutputValue(testOutput, 'Driver'));
   const driverDisplay = outputDriver ? driverLabel(outputDriver) : (configuredDriverLabel ?? 'Unknown driver');
-  const tableCount = Number(readOutputValue(testOutput, 'Tables') ?? NaN);
-  const testLines = ['✓ Connection test passed'];
-  testLines.push(`Driver: ${driverDisplay}${Number.isFinite(tableCount) ? ` · Tables: ${tableCount}` : ''}`);
+  const testLines = ['✓ Connection test passed', `Driver: ${driverDisplay}`];
   writeSetupSection(input.io, `Testing ${input.connectionId}`, testLines);
 
   if (!(await maybeConfigureSchemaScope(input))) {


### PR DESCRIPTION
## Summary
- **Reorder connection method prompt** — "Paste a connection URL" now appears first since it's the most common flow
- **Remove table counts from connection test output** — the count was noisy and not actionable; the scan step already reports detailed schema info

## Test plan
- [x] `setup-databases.test.ts` passes (36/36)
- [x] New test covers URL-first ordering across all URL-capable drivers (postgres, mysql, clickhouse, sqlserver)
- [x] Existing test updated to assert table count is no longer shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)