### PR TITLE
fix(cli): remove redundant path resolution hints from project setup

### DIFF
--- a/packages/cli/src/setup-project.ts
+++ b/packages/cli/src/setup-project.ts
@@ -204,8 +204,6 @@ async function promptForNewProjectDir(
   const defaultProjectDir = join(projectDir, DEFAULT_NEW_PROJECT_FOLDER_NAME);
 
   while (true) {
-    io.stdout.write(`│  Relative paths are resolved from:\n│    ${projectDir}\n`);
-    io.stdout.write(`│  Home paths are resolved from:\n│    ${homeDir}\n`);
     const destinationChoice = await prompts.select({
       message: 'Where should KTX create the project?',
       options: [
@@ -376,8 +374,6 @@ export async function runKtxSetupProjectStep(
     }
 
     if (choice === 'new-custom') {
-      io.stdout.write(`│  Relative paths are resolved from:\n│    ${projectDir}\n`);
-      io.stdout.write(`│  Home paths are resolved from:\n│    ${homeDir}\n`);
       const rawPath = await prompts.text({
         message: withTextInputNavigation('Project folder path'),
         placeholder: './analytics-ktx, ~/analytics-ktx, or /Users/you/projects/analytics-ktx',


### PR DESCRIPTION
## Summary
- Removes the "Relative paths are resolved from" and "Home paths are resolved from" messages shown during project folder selection in `ktx setup`
- The placeholder text (`./analytics-ktx, ~/analytics-ktx, or /Users/you/projects/analytics-ktx`) already communicates supported path formats, and the confirmation step shows the resolved path before creating anything

## Test plan
- [x] `setup-project.test.ts` — all 12 tests pass
- [ ] Manual: run `ktx setup` → "Create a new project folder" → verify no path hint noise before the destination prompt
- [ ] Manual: run `ktx setup` with existing project dir → "Create a new project at a custom path" → verify no path hint noise before the text input

🤖 Generated with [Claude Code](https://claude.com/claude-code)