### PR TITLE
fix: show setup destination paths

### DIFF
--- a/packages/cli/src/setup-project.test.ts
+++ b/packages/cli/src/setup-project.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { initKtxProject, parseKtxProjectConfig, readKtxSetupState } from '@ktx/context/project';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { gray } from './io/symbols.js';
 import { type KtxSetupProjectPromptAdapter, runKtxSetupProjectStep } from './setup-project.js';
 
 function makeIo(options: { stdoutIsTty?: boolean } = {}) {
@@ -35,6 +36,12 @@ function makePromptAdapter(options: { choice?: string; choices?: string[]; textV
     text: vi.fn(async () => textValues.shift() ?? ''),
     cancel: vi.fn(),
   } satisfies KtxSetupProjectPromptAdapter;
+}
+
+function defaultSubfolderLabel(parentDir: string): string {
+  const childName = 'ktx-project';
+  const childDir = join(parentDir, childName);
+  return `New subfolder (${gray(childDir.slice(0, -childName.length))}${childName})`;
 }
 
 describe('setup project step', () => {
@@ -143,8 +150,11 @@ describe('setup project step', () => {
       expect.objectContaining({
         message: 'Where should KTX create the project?',
         options: [
-          expect.objectContaining({ value: 'current', label: 'Current directory' }),
-          expect.objectContaining({ value: 'new-default', label: 'New subfolder (./ktx-project)' }),
+          expect.objectContaining({ value: 'current', label: `Current directory (${projectDir})` }),
+          expect.objectContaining({
+            value: 'new-default',
+            label: defaultSubfolderLabel(projectDir),
+          }),
           expect.objectContaining({ value: 'new-custom', label: 'Custom path' }),
           expect.objectContaining({ value: 'exit', label: 'Exit' }),
         ],
@@ -174,7 +184,10 @@ describe('setup project step', () => {
       expect.objectContaining({
         message: 'Where should KTX create the project?',
         options: expect.arrayContaining([
-          expect.objectContaining({ value: 'new-default', label: 'New subfolder (./ktx-project)' }),
+          expect.objectContaining({
+            value: 'new-default',
+            label: defaultSubfolderLabel(startDir),
+          }),
         ]),
       }),
     );

--- a/packages/cli/src/setup-project.ts
+++ b/packages/cli/src/setup-project.ts
@@ -12,6 +12,7 @@ import {
   serializeKtxProjectConfig,
 } from '@ktx/context/project';
 import type { KtxCliIo } from './cli-runtime.js';
+import { gray } from './io/symbols.js';
 import { withMenuOptionsSpacing, withTextInputNavigation } from './prompt-navigation.js';
 import { withSetupInterruptConfirmation } from './setup-interrupt.js';
 
@@ -321,6 +322,10 @@ export async function runKtxSetupProjectStep(
 
   const prompts = deps.prompts ?? createClackSetupProjectPromptAdapter();
   const defaultProjectDir = join(projectDir, DEFAULT_NEW_PROJECT_FOLDER_NAME);
+  const defaultProjectDirLabel = [
+    gray(defaultProjectDir.slice(0, -DEFAULT_NEW_PROJECT_FOLDER_NAME.length)),
+    DEFAULT_NEW_PROJECT_FOLDER_NAME,
+  ].join('');
   io.stdout.write(
     '│  Use Up/Down to move, Enter to confirm the current selection, choose Back to return to the previous step, Ctrl+C to exit.\n',
   );
@@ -328,8 +333,8 @@ export async function runKtxSetupProjectStep(
     const choice = await prompts.select({
       message: 'Where should KTX create the project?',
       options: [
-        { value: 'current', label: 'Current directory' },
-        { value: 'new-default', label: 'New subfolder (./ktx-project)' },
+        { value: 'current', label: `Current directory (${projectDir})` },
+        { value: 'new-default', label: `New subfolder (${defaultProjectDirLabel})` },
         { value: 'new-custom', label: 'Custom path' },
         ...(args.allowBack ? [{ value: 'back', label: 'Back' }] : []),
         ...(args.allowBack ? [] : [{ value: 'exit', label: 'Exit' }]),


### PR DESCRIPTION
Shows the active project directory next to Current directory and the absolute default subfolder path next to New subfolder, with only the parent path dimmed.

This makes the setup destination choices easier to distinguish before KTX creates files.

Checks: `pnpm --filter @ktx/cli exec vitest run src/setup-project.test.ts --testTimeout 30000`, `pnpm --filter @ktx/cli run type-check`, and `pnpm run dead-code`.