### PR TITLE
fix(cli): show project dir in context build step

### DIFF
--- a/packages/cli/src/context-build-view.test.ts
+++ b/packages/cli/src/context-build-view.test.ts
@@ -168,6 +168,15 @@ describe('renderContextBuildView', () => {
     expect(output).toContain('(0/1 · 1m05s)');
   });
 
+  it('renders project directory when provided', () => {
+    const state = initViewState([
+      { connectionId: 'warehouse', driver: 'postgres', operation: 'scan', debugCommand: '', steps: ['scan'] },
+    ]);
+
+    const output = renderContextBuildView(state, { styled: false, projectDir: '/tmp/project' });
+    expect(output).toContain('Project: /tmp/project');
+  });
+
   it('renders dynamic separator matching header width', () => {
     const state = initViewState([
       { connectionId: 'warehouse', driver: 'postgres', operation: 'scan', debugCommand: '', steps: ['scan'] },
@@ -448,6 +457,7 @@ describe('runContextBuild', () => {
 
     const output = io.stdout();
     expect(output).toContain('Building KTX context');
+    expect(output).toContain('Project: /tmp/project');
     expect(output).toContain('Primary sources:');
     expect(output).toContain('warehouse');
     expect(output).toContain('Context sources:');

--- a/packages/cli/src/context-build-view.ts
+++ b/packages/cli/src/context-build-view.ts
@@ -204,6 +204,7 @@ export function renderContextBuildView(
     '',
     header,
     separator,
+    ...(options.projectDir ? [`  Project: ${options.projectDir}`] : []),
     ...renderTargetGroup('Primary sources', state.primarySources, state.frame, styled, width),
     ...renderTargetGroup('Context sources', state.contextSources, state.frame, styled, width),
     '',
@@ -684,7 +685,7 @@ export async function runContextBuild(
   }
 
   if (!repainter) {
-    io.stdout.write(renderContextBuildView(state, { styled: false }));
+    io.stdout.write(renderContextBuildView(state, { ...viewOpts, styled: false }));
   } else {
     paint(false);
   }


### PR DESCRIPTION
Adds the KTX project directory to the context build progress view so users can see which project is being built. Reuses the existing projectDir render option for both TTY repainting and final non-TTY output. Adds tests for direct rendering and runContextBuild output. Validated with the targeted context build view test, CLI type-check, dead-code, and pre-commit checks.