### PR TITLE
Hide setup project banner

### DIFF
--- a/packages/cli/src/cli-program.ts
+++ b/packages/cli/src/cli-program.ts
@@ -162,6 +162,10 @@ function shouldSuppressProjectDirLine(path: string[], options: Record<string, un
     return true;
   }
 
+  if (commandPathKey === 'ktx setup') {
+    return true;
+  }
+
   if (
     commandPathKey === 'ktx status' &&
     typeof options.projectDir !== 'string' &&

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -333,6 +333,22 @@ describe('runKtxCli', () => {
     expect(testIo.stderr()).toBe(`Project: ${tempDir}\n`);
   });
 
+  it('does not print the command-level project directory line for setup', async () => {
+    const setup = vi.fn(async () => 0);
+    const testIo = makeIo();
+
+    await expect(runKtxCli(['--project-dir', tempDir, 'setup', '--no-input'], testIo.io, { setup })).resolves.toBe(0);
+
+    expect(setup).toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: 'run',
+        projectDir: tempDir,
+      }),
+      testIo.io,
+    );
+    expect(testIo.stderr()).toBe('');
+  });
+
   it('skips the project directory line for JSON and TUI output modes', async () => {
     const ingest = vi.fn(async () => 0);
     const jsonIo = makeIo();

--- a/packages/cli/src/project-dir.test.ts
+++ b/packages/cli/src/project-dir.test.ts
@@ -65,7 +65,7 @@ describe('project directory defaults', () => {
         argv: ['setup', '--no-input'],
         spy: setup,
         expected: { command: 'run', projectDir: '/tmp/ktx-env-project' },
-        expectedStderr: 'Project: /tmp/ktx-env-project\n',
+        expectedStderr: '',
       },
       {
         argv: ['scan', 'warehouse'],

--- a/packages/cli/src/standalone-smoke.test.ts
+++ b/packages/cli/src/standalone-smoke.test.ts
@@ -130,6 +130,10 @@ function expectProjectStderr(result: CliResult, projectDir: string): void {
   expect(result).toMatchObject({ code: 0, stderr: `Project: ${projectDir}\n` });
 }
 
+function expectSetupStderr(result: CliResult): void {
+  expect(result).toMatchObject({ code: 0, stderr: '' });
+}
+
 async function runSetupNewProject(projectDir: string): Promise<CliResult> {
   return await runBuiltCli([
     'setup',
@@ -162,7 +166,7 @@ describe('standalone built ktx CLI smoke', () => {
     const sourceDir = join(tempDir, 'source');
 
     const init = await runSetupNewProject(projectDir);
-    expectProjectStderr(init, projectDir);
+    expectSetupStderr(init);
     expect(init.stdout).toContain(`Project: ${projectDir}`);
 
     await writeWarehouseConfig(projectDir);
@@ -207,7 +211,7 @@ describe('standalone built ktx CLI smoke', () => {
   it('runs structural and enriched scans through the built binary with manifest artifacts', async () => {
     const projectDir = join(tempDir, 'scan-project');
     const init = await runSetupNewProject(projectDir);
-    expectProjectStderr(init, projectDir);
+    expectSetupStderr(init);
 
     const dbPath = join(projectDir, 'warehouse.db');
     createSqliteWarehouse(dbPath);
@@ -310,7 +314,7 @@ describe('standalone built ktx CLI smoke', () => {
   it('rejects the removed connection add command through the built binary', async () => {
     const projectDir = join(tempDir, 'notion-project');
     const init = await runSetupNewProject(projectDir);
-    expectProjectStderr(init, projectDir);
+    expectSetupStderr(init);
 
     const add = await runBuiltCli([
       'connection',

--- a/scripts/package-artifacts.mjs
+++ b/scripts/package-artifacts.mjs
@@ -618,7 +618,7 @@ try {
     '--skip-sources',
     '--skip-agents',
   ]);
-  requireProjectStderr('ktx setup', init, projectDir);
+  requireSuccess('ktx setup', init);
   requireOutput('ktx setup', init, /Project: /);
 
   const emptyProjectDir = join(root, 'empty-project');
@@ -637,7 +637,7 @@ try {
     '--skip-sources',
     '--skip-agents',
   ]);
-  requireProjectStderr('ktx setup empty project', emptyInit, emptyProjectDir);
+  requireSuccess('ktx setup empty project', emptyInit);
   await writeFile(
     join(projectDir, 'ktx.yaml'),
     [


### PR DESCRIPTION
## Summary
- Suppress the command-level `Project: ...` stderr banner for `ktx setup`.
- Keep other project-aware command banners unchanged.
- Update CLI dispatcher, smoke, and artifact checks for the new setup stderr behavior.

## Test Plan
- `pnpm --filter @ktx/cli exec vitest run src/index.test.ts src/project-dir.test.ts`
- `pnpm --filter @ktx/cli run type-check`

Additional local verification before commit:
- `pnpm run dead-code`
- `node --check scripts/package-artifacts.mjs`
- `pnpm --filter @ktx/cli run test`
- `pnpm --filter @ktx/cli run build`
- `pnpm --filter @ktx/cli exec vitest run src/standalone-smoke.test.ts --testNamePattern "reports missing local ingest|runs structural and enriched scans|rejects the removed connection add" --testTimeout 30000`