### PR TITLE
feat(docs-site): add "by Kaelio" attribution and enlarge nav logo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Playwright CLI session artifacts (snapshots, console logs, screenshots)
+.playwright-cli/
+
 # Python
 __pycache__/
 *.py[cod]

--- a/docs-site/components/logo.tsx
+++ b/docs-site/components/logo.tsx
@@ -1,28 +1,36 @@
 export function Logo() {
   return (
-    <div className="flex items-center gap-2.5 group">
+    <div className="flex items-center gap-3.5 group">
       <div className="relative flex items-center justify-center transition-transform duration-300 ease-out group-hover:rotate-[-4deg]">
         <img
-          src="/brand/ktx-mascot.svg"
+          src="/ktx/brand/ktx-mascot.svg"
           alt=""
           aria-hidden="true"
-          className="h-14 w-14 object-contain block dark:hidden"
+          className="h-20 w-20 object-contain block dark:hidden"
         />
         <img
-          src="/brand/ktx-mascot-dark.svg"
+          src="/ktx/brand/ktx-mascot-dark.svg"
           alt=""
           aria-hidden="true"
-          className="h-14 w-14 object-contain hidden dark:block"
+          className="h-20 w-20 object-contain hidden dark:block"
         />
       </div>
+      <div className="flex flex-col items-start leading-none">
+        <span
+          className="text-[24px] font-semibold text-fd-foreground tracking-tight"
+          style={{ fontFamily: "var(--font-display), var(--font-sans), sans-serif" }}
+        >
+          KTX
+        </span>
+        <span
+          className="mt-1 whitespace-nowrap text-[13px] font-medium text-fd-muted-foreground/80 tracking-tight"
+          style={{ fontFamily: "var(--font-display), var(--font-sans), sans-serif" }}
+        >
+          by Kaelio
+        </span>
+      </div>
       <span
-        className="text-[17px] font-semibold text-fd-foreground tracking-tight"
-        style={{ fontFamily: "var(--font-display), var(--font-sans), sans-serif" }}
-      >
-        KTX
-      </span>
-      <span
-        className="text-[14px] font-medium text-fd-muted-foreground/80 tracking-tight border-l border-fd-border pl-2 ml-0.5"
+        className="text-[19px] font-medium text-fd-muted-foreground/80 tracking-tight border-l border-fd-border pl-3 ml-1"
         style={{ fontFamily: "var(--font-display), var(--font-sans), sans-serif" }}
       >
         Docs


### PR DESCRIPTION
## Summary
- Stack a small "by Kaelio" line under the KTX wordmark in the docs site nav logo and scale the mascot + wordmark ~1.4x for more presence.
- Fix mascot asset paths to include the `/ktx` basePath so they actually load (raw `<img>` doesn't auto-prefix like `next/image` does).
- Ignore `.playwright-cli/` session artifacts left behind by local UI verification runs.

## Test plan
- [ ] Visit a docs page locally and confirm the mascot + "KTX / by Kaelio | Docs" logo renders correctly in light and dark mode
- [ ] Verify mascot SVG returns 200 (not 404) at `/ktx/brand/ktx-mascot.svg`
- [ ] Confirm "by Kaelio" stays on a single line at the docs nav width