### PR TITLE
Move LLM configuration guide last

### DIFF
--- a/docs-site/content/docs/guides/meta.json
+++ b/docs-site/content/docs/guides/meta.json
@@ -1,5 +1,5 @@
 {
   "title": "Guides",
   "defaultOpen": true,
-  "pages": ["building-context", "llm-configuration", "writing-context", "serving-agents"]
+  "pages": ["building-context", "writing-context", "serving-agents", "llm-configuration"]
 }


### PR DESCRIPTION
## Summary
- Reorders the Guides sidebar so `LLM configuration` appears last.
- Keeps the change to a single focused docs metadata commit.

## Test Plan
- `node -e "JSON.parse(require('fs').readFileSync('docs-site/content/docs/guides/meta.json','utf8')); console.log('guides meta json ok')"`
- `pnpm --filter ktx-docs test`
