### PR TITLE
fix: align release provenance metadata

### DIFF
--- a/packages/connector-clickhouse/src/package-exports.test.ts
+++ b/packages/connector-clickhouse/src/package-exports.test.ts
@@ -1,12 +1,16 @@
 import { describe, expect, it } from 'vitest';
 
 describe('@ktx/connector-clickhouse package exports', () => {
-  it('exports public connector APIs during package bootstrap', async () => {
-    const connector = await import('./index.js');
+  it(
+    'exports public connector APIs during package bootstrap',
+    async () => {
+      const connector = await import('./index.js');
 
-    expect(connector.KtxClickHouseDialect).toBeTypeOf('function');
-    expect(connector.KtxClickHouseScanConnector).toBeTypeOf('function');
-    expect(connector.clickHouseClientConfigFromConfig).toBeTypeOf('function');
-    expect(connector.createClickHouseLiveDatabaseIntrospection).toBeTypeOf('function');
-  });
+      expect(connector.KtxClickHouseDialect).toBeTypeOf('function');
+      expect(connector.KtxClickHouseScanConnector).toBeTypeOf('function');
+      expect(connector.clickHouseClientConfigFromConfig).toBeTypeOf('function');
+      expect(connector.createClickHouseLiveDatabaseIntrospection).toBeTypeOf('function');
+    },
+    20_000,
+  );
 });

--- a/scripts/build-public-npm-package.mjs
+++ b/scripts/build-public-npm-package.mjs
@@ -146,12 +146,12 @@ export function publicNpmPackageJson(cliPackageJson, dependencies, version = PUB
     license: cliPackageJson.license ?? 'Apache-2.0',
     repository: {
       type: 'git',
-      url: 'git+https://github.com/kaelio/ktx.git',
+      url: 'https://github.com/Kaelio/ktx',
     },
     bugs: {
-      url: 'https://github.com/kaelio/ktx/issues',
+      url: 'https://github.com/Kaelio/ktx/issues',
     },
-    homepage: 'https://github.com/kaelio/ktx#readme',
+    homepage: 'https://github.com/Kaelio/ktx#readme',
   };
 }
 

--- a/scripts/build-public-npm-package.test.mjs
+++ b/scripts/build-public-npm-package.test.mjs
@@ -217,6 +217,14 @@ describe('publicNpmPackageJson', () => {
     assert.deepEqual(packageJson.dependencies, { commander: '14.0.3' });
     assert.deepEqual(packageJson.bundledDependencies, PUBLIC_BUNDLED_WORKSPACE_PACKAGES);
     assert.deepEqual(packageJson.files, ['dist', 'assets']);
+    assert.deepEqual(packageJson.repository, {
+      type: 'git',
+      url: 'https://github.com/Kaelio/ktx',
+    });
+    assert.deepEqual(packageJson.bugs, {
+      url: 'https://github.com/Kaelio/ktx/issues',
+    });
+    assert.equal(packageJson.homepage, 'https://github.com/Kaelio/ktx#readme');
   });
 });
 


### PR DESCRIPTION
Root cause: the live stable release reached npm publish, but npm rejected trusted provenance because the generated public package metadata used git+https://github.com/kaelio/ktx.git while Actions provenance reported https://github.com/Kaelio/ktx.

This PR updates the generated @kaelio/ktx package metadata to match the Actions provenance repository URL exactly and adds a regression assertion.

It also raises the ClickHouse package export test timeout to avoid the separate coverage timeout seen on PR #145.

Validation: node --test scripts/build-public-npm-package.test.mjs; node --test scripts/*.test.mjs; pnpm --filter @ktx/connector-clickhouse run build; pnpm --filter @ktx/connector-clickhouse run test --coverage --coverage.reporter=lcov --coverage.exclude=dist/**; pnpm --filter @ktx/connector-clickhouse run type-check; pnpm run artifacts:check; pnpm run dead-code.