### PR TITLE
docs: align CLI install package manager guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ to install and configure ktx
 ## Quick Start
 
 ```bash
-pnpm add --global @kaelio/ktx
+npm install -g @kaelio/ktx
 ktx setup
 ktx status
 ```

--- a/docs-site/content/docs/ai-resources/prompt-recipes.mdx
+++ b/docs-site/content/docs/ai-resources/prompt-recipes.mdx
@@ -14,7 +14,7 @@ Read https://docs.kaelio.com/ktx/llms.txt first. Then fetch only the KTX Markdow
 ## Set up a project
 
 ```text
-Set up KTX in this repository. Start by reading /docs/ai-resources/agent-quickstart.md and /docs/getting-started/quickstart.md. Use pnpm, not npm. After setup, run ktx status and summarize which steps are complete, which files changed, and what still needs credentials or user input.
+Set up KTX in this repository. Start by reading /docs/ai-resources/agent-quickstart.md and /docs/getting-started/quickstart.md. Install the published CLI with npm; use pnpm only when working from a KTX source checkout. After setup, run ktx status and summarize which steps are complete, which files changed, and what still needs credentials or user input.
 ```
 
 ## Find a command

--- a/scripts/examples-docs.test.mjs
+++ b/scripts/examples-docs.test.mjs
@@ -192,7 +192,7 @@ describe('standalone example docs', () => {
     const quickstart = await readText('docs-site/content/docs/getting-started/quickstart.mdx');
     const packageArtifacts = await readText('examples/package-artifacts/README.md');
 
-    assert.match(rootReadme, publicPackagePattern('pnpm add --global {package}'));
+    assert.match(rootReadme, publicPackagePattern('npm install -g {package}'));
     assert.match(quickstart, publicPackagePattern('npm install -g {package}'));
     assert.match(quickstart, /ktx dev runtime install --feature local-embeddings --yes/);
     assert.match(quickstart, /ktx dev runtime start --feature local-embeddings/);


### PR DESCRIPTION
## Summary
- Use npm for the published CLI install command in the README quick start.
- Clarify that pnpm is only for working from a KTX source checkout in the agent prompt recipe.

## Validation
- Reviewed `git diff origin/main...`.
