### PR TITLE
chore: preserve superpowers docs symlink in worktrees

### DIFF
--- a/scripts/conductor-setup.sh
+++ b/scripts/conductor-setup.sh
@@ -109,6 +109,8 @@ link_agent_overlays() {
   if [ -n "${CONDUCTOR_ROOT_PATH:-}" ]; then
     link_shared_path "$CONDUCTOR_ROOT_PATH/.agents" .agents || true
     link_shared_path "$CONDUCTOR_ROOT_PATH/.claude" .claude || true
+    mkdir -p docs
+    link_shared_path "$CONDUCTOR_ROOT_PATH/docs/superpowers" docs/superpowers || true
   fi
 }
 


### PR DESCRIPTION
Preserves the local `docs/superpowers` overlay when Conductor creates KTX worktrees by linking it from `$CONDUCTOR_ROOT_PATH` during setup.

This keeps agent superpowers specs available alongside existing `.agents` and `.claude` overlays without tracking the ignored symlink.

Validation: `bash -n scripts/conductor-setup.sh`.