### PR TITLE
fix(ci): publish the pre-built tarball instead of re-packing

### DIFF
--- a/scripts/check-boundaries.mjs
+++ b/scripts/check-boundaries.mjs
@@ -11,6 +11,7 @@ const identifierAllowPatterns = [
   /^packages\/cli\/src\/(?:index|managed-local-embeddings|managed-python-command|managed-python-daemon|managed-python-runtime|release-version|runtime)(?:\.test)?\.ts$/,
   /^python\/ktx-daemon\/src\/ktx_daemon\/__init__\.py$/,
   /^scripts\/(?:build-public-npm-package|build-python-runtime-wheel|local-embeddings-runtime-smoke|package-artifacts|public-npm-release-metadata|published-package-smoke|release-readiness)(?:\.test)?\.mjs$/,
+  /^scripts\/semantic-release-config\.cjs$/,
 ];
 const forbiddenIdentifierTerms = ['kae' + 'lio', 'Kae' + 'lio', 'KAE' + 'LIO_'];
 

--- a/scripts/check-boundaries.test.mjs
+++ b/scripts/check-boundaries.test.mjs
@@ -79,6 +79,7 @@ describe('scanFileContent', () => {
     assert.equal(scanFileContent('scripts/local-embeddings-runtime-smoke.mjs', `@${name}/ktx`).length, 0);
     assert.equal(scanFileContent('scripts/package-artifacts.test.mjs', `${name}-ktx`).length, 0);
     assert.equal(scanFileContent('scripts/public-npm-release-metadata.mjs', `@${name}/ktx`).length, 0);
+    assert.equal(scanFileContent('scripts/semantic-release-config.cjs', `${name}-ktx-`).length, 0);
     assert.equal(scanFileContent('packages/cli/src/release-version.ts', `@${name}/ktx`).length, 0);
     assert.equal(scanFileContent('packages/cli/src/managed-python-runtime.ts', `${name}_ktx`).length, 0);
     assert.equal(scanFileContent('python/ktx-daemon/src/ktx_daemon/__init__.py', `${name}-ktx`).length, 0);

--- a/scripts/semantic-release-config.cjs
+++ b/scripts/semantic-release-config.cjs
@@ -166,19 +166,10 @@ function createReleaseConfig(env = process.env) {
             'pnpm run artifacts:check',
             'pnpm run release:readiness',
           ].join(' && '),
-        },
-      ],
-      [
-        '@semantic-release/npm',
-        {
-          pkgRoot: 'dist/public-npm-package',
-          tarballDir: 'dist/artifacts/npm',
-        },
-      ],
-      [
-        '@semantic-release/exec',
-        {
-          publishCmd: 'pnpm run release:published-smoke',
+          publishCmd: [
+            `npm publish dist/artifacts/npm/kaelio-ktx-\${nextRelease.version}.tgz --tag ${tag} --access public --provenance`,
+            'pnpm run release:published-smoke',
+          ].join(' && '),
         },
       ],
       ...releaseGitPlugins(kind),

--- a/scripts/semantic-release-config.test.mjs
+++ b/scripts/semantic-release-config.test.mjs
@@ -27,20 +27,20 @@ describe('semantic-release config', () => {
     ]);
 
     const config = createReleaseConfig({ KTX_RELEASE_KIND: 'rc', GITHUB_REF_NAME: 'main' });
-    assert.deepEqual(
+    assert.equal(
       config.plugins.find((plugin) => Array.isArray(plugin) && plugin[0] === '@semantic-release/npm'),
-      [
-        '@semantic-release/npm',
-        {
-          pkgRoot: 'dist/public-npm-package',
-          tarballDir: 'dist/artifacts/npm',
-        },
-      ],
+      undefined,
+      '@semantic-release/npm must not run; the exec publishCmd publishes the pre-built tarball',
     );
     assert.match(
       releaseExecOptions(config).prepareCmd,
       /update-public-release-version\.mjs "\$\{nextRelease\.version\}" "next"/,
     );
+    assert.match(
+      releaseExecOptions(config).publishCmd,
+      /^npm publish dist\/artifacts\/npm\/kaelio-ktx-\$\{nextRelease\.version\}\.tgz --tag next --access public --provenance/,
+    );
+    assert.match(releaseExecOptions(config).publishCmd, /pnpm run release:published-smoke/);
     assert.doesNotMatch(JSON.stringify(config.plugins), /release:npm-publish/);
     const releaseFilePluginNames = pluginNames(config).filter(
       (plugin) => plugin === '@semantic-release/changelog' || plugin === '@semantic-release/git',
@@ -61,6 +61,10 @@ describe('semantic-release config', () => {
     assert.match(
       releaseExecOptions(config).prepareCmd,
       /update-public-release-version\.mjs "\$\{nextRelease\.version\}" "latest"/,
+    );
+    assert.match(
+      releaseExecOptions(config).publishCmd,
+      /^npm publish dist\/artifacts\/npm\/kaelio-ktx-\$\{nextRelease\.version\}\.tgz --tag latest --access public --provenance/,
     );
     assert.equal(config.plugins.includes('./scripts/semantic-release-version-policy.cjs'), false);
   });


### PR DESCRIPTION
## Summary

- Last [KTX Release run](https://github.com/Kaelio/ktx/actions/runs/26128501437) failed at the `Create semantic release` step with `Error: dest already exists` from `fs-extra` `move`. No `v0.1.1` was published.
- Root cause: the release flow built the tarball **twice** — once via `pnpm pack` in `artifacts:check` (which leaves it at `dist/artifacts/npm/kaelio-ktx-<v>.tgz`) and once inside `@semantic-release/npm`'s `prepare`, which then tried to `move` its own `npm pack` output into the same directory and crashed. Beyond being a publish blocker, that also meant the *published* tarball was a different file than the one verified by `artifacts:check`.
- Fix: drop `@semantic-release/npm` from the plugin list and publish the exact tarball that `artifacts:check` produced and smoke-tested, via an exec `publishCmd`:

  ```
  npm publish dist/artifacts/npm/kaelio-ktx-<v>.tgz \
    --tag <next|latest> --access public --provenance
  ```

- Auth model is unchanged — OIDC trusted publishing. The workflow already grants `id-token: write` and `actions/setup-node` configures the registry; `release-workflow.test.mjs` asserts `NODE_AUTH_TOKEN` is not set.

This is the "build once, verify that exact artifact, publish that same file" pattern. Regression was introduced by #149, which simplified the flow but left two steps writing to the same path.

## Out of scope (follow-ups)

- Remove `@semantic-release/npm` from `package.json` devDeps + `knip.json` `ignoreDependencies` (touches `pnpm-lock.yaml`).
- Remove the now-unused `Prepare npm package root for release verification` step from `.github/workflows/release.yml` (also updates `release-workflow.test.mjs`).

## Test plan

- [x] `node --test scripts/semantic-release-config.test.mjs scripts/release-workflow.test.mjs scripts/public-npm-release-metadata.test.mjs` — 10/10 pass
- [x] Rendered config inspected for both `rc` and `stable` kinds — `publishCmd` produces `npm publish ... --tag next` and `--tag latest` respectively, and `@semantic-release/npm` is not in the plugin list.
- [ ] After merge: re-trigger the `KTX Release` workflow (`release_kind=stable`, `publish_live=true`) and confirm `@kaelio/ktx@0.1.1` is published to npm and the post-publish smoke passes.