### PR TITLE
fix(docs): stop semantic-layer flow from trapping page scroll

### DIFF
--- a/docs-site/components/semantic-layer-flow.tsx
+++ b/docs-site/components/semantic-layer-flow.tsx
@@ -4,7 +4,6 @@ import { useCallback, useState } from "react";
 import {
   Background,
   BackgroundVariant,
-  Controls,
   Handle,
   MarkerType,
   type Node,
@@ -1036,7 +1035,7 @@ export function SemanticLayerFlow() {
           }}
         >
           <div className="pointer-events-none absolute right-2.5 top-2.5 z-10 rounded border border-fd-border/50 bg-white/30 px-1.5 py-px font-mono text-[9.5px] font-medium uppercase tracking-[0.06em] text-fd-muted-foreground shadow-sm backdrop-blur-sm dark:bg-white/10">
-            Pan / zoom
+            Drag to pan • ⌘/Ctrl + scroll to zoom
           </div>
           <ReactFlow
             nodes={nodes}
@@ -1050,15 +1049,14 @@ export function SemanticLayerFlow() {
             elementsSelectable={false}
             panOnDrag
             panOnScroll={false}
-            zoomOnScroll
+            zoomOnScroll={false}
             zoomOnPinch
             zoomOnDoubleClick
-            preventScrolling
+            preventScrolling={false}
             minZoom={minZoom}
             maxZoom={1.5}
             proOptions={{ hideAttribution: true }}
           >
-            <Controls position="bottom-right" showInteractive={false} />
             <Background
               variant={BackgroundVariant.Dots}
               gap={18}


### PR DESCRIPTION
## Summary

The embedded ReactFlow diagram on `/docs/concepts/semantic-layer-internals` was capturing wheel events and blocking page scroll the moment the pointer crossed into it — even when the diagram was already at min zoom — because `zoomOnScroll` + `preventScrolling` (both default-on) call `preventDefault` on every wheel event over the canvas.

## Changes

- `docs-site/components/semantic-layer-flow.tsx`: set `zoomOnScroll={false}` and `preventScrolling={false}` so plain wheel/trackpad scroll passes through to the page.
- Removed the `<Controls />` component — positioned bottom-right of a 2340px-tall canvas, so the +/− buttons were off-screen and effectively dead UI.
- Switched to Google-Maps-style zoom: drag to pan, double-click to zoom in, pinch on trackpads, and ⌘/Ctrl + scroll (xyflow's default `zoomActivationKeyCode`, auto-detected per platform).
- Hint badge updated from "Pan / zoom" to "Drag to pan • ⌘/Ctrl + scroll to zoom".

## Test plan

- [ ] Open `/docs/concepts/semantic-layer-internals` and scroll from the top — page scrolls continuously through the diagram instead of getting trapped.
- [ ] Cmd/Ctrl + scroll over the diagram zooms in/out.
- [ ] Double-click and trackpad pinch still zoom; click-drag still pans.