### PR TITLE
chore(community): rewards program, issue templates, and triage workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,56 @@
+name: Bug report
+description: Report something that isn't working
+title: "[bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For questions or general discussion, use the
+        [KTX Slack](https://join.slack.com/t/ktxcommunity/shared_invite/zt-3y9b44m1x-LVyNNJD5nwaZHq4XS29LMQ).
+  - type: textarea
+    id: bug
+    attributes:
+      label: What's the bug?
+      description: What happened, and what did you expect?
+      placeholder: When I run `ktx ingest --all`, the Postgres connector fails with X. I expected Y.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: How can we reproduce it?
+      description: Commands or steps. A minimal example helps.
+      render: shell
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: KTX version
+      placeholder: "0.x.x"
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Which area?
+      options:
+        - CLI / setup
+        - Connector (Postgres)
+        - Connector (Snowflake)
+        - Connector (BigQuery)
+        - Connector (MySQL)
+        - Connector (SQL Server)
+        - Connector (SQLite)
+        - Python semantic layer
+        - Python daemon
+        - Docs
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else?
+      description: OS, Node/Python versions, logs, screenshots. Redact secrets.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: false
+contact_links:
+  - name: KTX Slack — questions and chat
+    url: https://join.slack.com/t/ktxcommunity/shared_invite/zt-3y9b44m1x-LVyNNJD5nwaZHq4XS29LMQ
+    about: Ask a question, share what you're building, or get help from maintainers and other users. Faster than filing an issue.
+  - name: Documentation
+    url: https://docs.kaelio.com/ktx/docs/
+    about: Many setup, configuration, and integration questions are answered here.
+  - name: Community & Support guide
+    url: https://docs.kaelio.com/ktx/docs/community/support
+    about: Full guide on where to ask what — Slack vs. GitHub Issues vs. docs.
+  - name: Security issues
+    url: https://github.com/Kaelio/ktx/security/advisories/new
+    about: Report security vulnerabilities privately via GitHub Security Advisories. Please do not file security issues publicly.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,39 @@
+name: Feature request
+description: Propose a new feature or improvement
+title: "[feature] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For bug reports, use the bug template. For questions, use the
+        [KTX Slack](https://join.slack.com/t/ktxcommunity/shared_invite/zt-3y9b44m1x-LVyNNJD5nwaZHq4XS29LMQ).
+  - type: textarea
+    id: request
+    attributes:
+      label: What do you want, and why?
+      description: Describe the problem and your proposed solution.
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Which area?
+      options:
+        - CLI / setup
+        - Connectors
+        - Context engine
+        - Python semantic layer
+        - Python daemon
+        - Docs
+        - Other
+    validations:
+      required: true
+  - type: checkboxes
+    id: contribute
+    attributes:
+      label: Want to contribute this?
+      options:
+        - label: Yes, I'd like to open a PR
+        - label: I'd like guidance, then I'll open a PR
+        - label: No, just reporting the idea

--- a/.github/workflows/triage-issues.yml
+++ b/.github/workflows/triage-issues.yml
@@ -1,0 +1,28 @@
+name: Triage new issues
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  label-external:
+    name: Add needs-triage to external issues
+    runs-on: ubuntu-latest
+    if: |
+      github.event.issue.author_association != 'OWNER' &&
+      github.event.issue.author_association != 'MEMBER' &&
+      github.event.issue.author_association != 'COLLABORATOR'
+    steps:
+      - name: Apply needs-triage label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['needs-triage'],
+            });

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,94 @@
+# Contributing to KTX
+
+Thanks for your interest in KTX. This page covers **how to contribute** and
+the **contributor rewards program**. For development setup, repository
+layout, and verification commands, see the
+[Contributing guide in the docs](https://docs.kaelio.com/ktx/docs/community/contributing).
+
+## How to contribute
+
+1. Browse open issues labeled
+   [`good first issue`](https://github.com/Kaelio/ktx/labels/good%20first%20issue)
+   or [`help wanted`](https://github.com/Kaelio/ktx/labels/help%20wanted).
+2. Comment on the issue to claim it. A maintainer will confirm scope and
+   assign it to you.
+3. For changes not covered by an existing issue, open one first so we can
+   align on scope before you write code.
+4. Open a pull request that resolves the issue. Keep it focused — one
+   logical change per PR.
+5. Run the relevant checks before requesting review. See the
+   [docs contributing page](https://docs.kaelio.com/ktx/docs/community/contributing#running-tests)
+   for the right commands per area.
+
+## Contributor rewards program
+
+We send merch to contributors whose pull requests get merged. The goal is
+to thank the people building KTX with us, not to drive volume.
+
+### How it works
+
+1. A maintainer marks an issue `reward:eligible` when it's ready for an
+   outside contributor.
+2. You open a PR that resolves the issue.
+3. A maintainer reviews and merges.
+4. After merge, the maintainer adds a `reward:tier-*` label and replies
+   on the PR asking you to email `support@kaelio.com` with your shipping
+   address, size (if applicable), and a link to the merged PR.
+5. We ship within four weeks.
+
+### Reward tiers
+
+| Tier | Reward | Earned by |
+|------|--------|-----------|
+| 1 | Sticker pack | Your first merged PR, any size |
+| 2 | T-shirt | A substantive merged PR: bug fix with a regression test, new docs page, connector test fixture, CLI improvement |
+| 3 | Hoodie | Three or more merged PRs, or one major contribution (new integration, significant feature) |
+
+Maintainers decide tier; decisions are final. Tiers do not stack on the
+same PR.
+
+### Eligibility
+
+- Only **merged** PRs count. Closed-without-merge or stale PRs do not earn
+  rewards.
+- The GitHub account must be at least 30 days old at the time the PR is
+  opened.
+- The PR must resolve a real issue or measurable improvement.
+- We ship worldwide where customs allow. If we cannot ship to your region
+  we will substitute an equivalent (gift card or digital).
+
+### Not eligible
+
+- Typo-only PRs and whitespace/formatting changes
+- Drive-by style or lint cleanup without prior discussion
+- Mass reformatting or wrapper/abstraction churn
+- AI-generated PRs that do not pass review on their first revision
+- PRs that bundle unrelated changes
+- Anything that would be reverted in code review
+
+We use these rules to keep the program sustainable and to protect the
+quality of the project. They are not a judgment on contributors — they
+exist so a small maintainer team can keep saying yes.
+
+## Where to ask what
+
+See the [Community & Support](https://docs.kaelio.com/ktx/docs/community/support)
+page for the full guide. The short version:
+
+- **Questions, "how do I...", setup help, sharing patterns**: join the
+  [KTX Slack](https://join.slack.com/t/ktxcommunity/shared_invite/zt-3y9b44m1x-LVyNNJD5nwaZHq4XS29LMQ).
+- **Bugs**: use the [Bug report](.github/ISSUE_TEMPLATE/bug_report.yml)
+  template.
+- **Feature requests**: use the
+  [Feature request](.github/ISSUE_TEMPLATE/feature_request.yml) template.
+- **Security**: report privately via
+  [GitHub Security Advisories](https://github.com/Kaelio/ktx/security/advisories/new),
+  not as a public issue.
+
+## Code of conduct
+
+KTX follows the
+[Contributor Covenant](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
+Be respectful, assume good intent, and keep discussion focused on the
+project. Report concerns to the maintainers in Slack or by email at
+`support@kaelio.com`.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+If you believe you've found a security vulnerability in KTX, please report it
+**privately** through GitHub Security Advisories:
+
+[Report a vulnerability](https://github.com/Kaelio/ktx/security/advisories/new)
+
+If you cannot use GitHub Security Advisories, email `support@kaelio.com`
+instead. Please do **not** open a public issue, post in the KTX Slack, or
+share details elsewhere until we have published a fix.
+
+When reporting, please include:
+
+- A description of the issue and its impact
+- Steps to reproduce
+- The KTX version affected
+
+## What to expect
+
+- We will acknowledge your report within a few business days.
+- We will work with you to verify the issue and develop a fix.
+- We will credit you in the resulting advisory unless you prefer to remain
+  anonymous.
+
+## Supported versions
+
+We provide security fixes for the latest released version of
+[`@kaelio/ktx`](https://www.npmjs.com/package/@kaelio/ktx). Older versions
+may receive fixes at the maintainers' discretion.


### PR DESCRIPTION
## Summary

Adds the public-facing community engagement infrastructure that backs the [14 connector contribution issues](https://github.com/Kaelio/ktx/issues?q=is%3Aissue+is%3Aopen+label%3Aarea%3Aconnectors) (#161-174) filed for the rewards program launch.

- **`CONTRIBUTING.md`** — three-tier rewards program (sticker → t-shirt → hoodie), eligibility rules gated on merged PRs, fulfillment via `support@kaelio.com`. Links out to the existing `docs-site/content/docs/community/contributing.mdx` for development setup so nothing is duplicated.
- **`SECURITY.md`** — private reporting channel (GitHub Security Advisories with `support@kaelio.com` as fallback), expected reporter info, supported-version policy.
- **`.github/ISSUE_TEMPLATE/bug_report.yml`** — 5 fields, 4 required. Area dropdown excludes ClickHouse (intentionally disabled).
- **`.github/ISSUE_TEMPLATE/feature_request.yml`** — 3 fields, 2 required. Includes a "want to contribute?" checkbox.
- **`.github/ISSUE_TEMPLATE/config.yml`** — disables blank issues, routes questions to the KTX Slack (matching the routing established in `docs-site/.../community/support.mdx`).
- **`.github/workflows/triage-issues.yml`** — on issue open, applies `needs-triage` only when `author_association` is NOT `OWNER` / `MEMBER` / `COLLABORATOR`. Internal issues stay clean; external contributions get queued.

The label scheme (`reward:tier-1/2/3`, `reward:eligible`, `reward:claimed`, `area:cli` / `connectors` / `context` / `llm` / `docs`, `needs-triage`) has already been created on the repo.

## Test plan

- [ ] After merge, open the [New Issue](https://github.com/Kaelio/ktx/issues/new/choose) page and confirm the two templates render with the Slack-routing notice and the simplified fields
- [ ] File a test issue from a non-maintainer account (or someone outside the org) and confirm the `triage-issues` workflow adds `needs-triage`
- [ ] File a test issue as a maintainer and confirm `needs-triage` is NOT added
- [ ] Confirm the [Security tab](https://github.com/Kaelio/ktx/security/policy) renders the new `SECURITY.md`
- [ ] Pick the SHA for `actions/github-script@v7` and update the workflow to match the repo's SHA-pin convention (currently uses the version tag)

## Related

- Filed contribution issues: #161 through #174 (Redshift, Databricks, DuckDB, Athena, Synapse, Tableau, Power BI, Sigma, Confluence, Slack, SharePoint, ClickHouse, Google Drive, Jira)

🤖 Generated with [Claude Code](https://claude.com/claude-code)