### PR TITLE
fix: resolve dependabot security advisories

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,13 @@ settings:
 
 overrides:
   '@types/node': ^24.3.0
+  brace-expansion@>=5.0.0 <5.0.6: 5.0.6
+  fast-uri: 3.1.2
+  fast-xml-builder: 1.1.7
+  hono: 4.12.18
+  ip-address: 10.1.1
+  postcss: 8.5.10
+  ws: 8.20.1
 
 importers:
 
@@ -111,25 +118,25 @@ importers:
         version: 14.0.0(commander@14.0.3)
       '@ktx/connector-bigquery':
         specifier: workspace:*
-        version: file:packages/connector-bigquery(js-yaml@4.1.1)(ws@8.20.0)
+        version: file:packages/connector-bigquery(js-yaml@4.1.1)(ws@8.20.1)
       '@ktx/connector-clickhouse':
         specifier: workspace:*
-        version: file:packages/connector-clickhouse(js-yaml@4.1.1)(ws@8.20.0)
+        version: file:packages/connector-clickhouse(js-yaml@4.1.1)(ws@8.20.1)
       '@ktx/connector-mysql':
         specifier: workspace:*
-        version: file:packages/connector-mysql(@types/node@24.12.2)(js-yaml@4.1.1)(ws@8.20.0)
+        version: file:packages/connector-mysql(@types/node@24.12.2)(js-yaml@4.1.1)(ws@8.20.1)
       '@ktx/connector-postgres':
         specifier: workspace:*
-        version: file:packages/connector-postgres(js-yaml@4.1.1)(ws@8.20.0)
+        version: file:packages/connector-postgres(js-yaml@4.1.1)(ws@8.20.1)
       '@ktx/connector-snowflake':
         specifier: workspace:*
-        version: file:packages/connector-snowflake(asn1.js@5.4.1)(js-yaml@4.1.1)(ws@8.20.0)
+        version: file:packages/connector-snowflake(asn1.js@5.4.1)(js-yaml@4.1.1)(ws@8.20.1)
       '@ktx/connector-sqlite':
         specifier: workspace:*
-        version: file:packages/connector-sqlite(js-yaml@4.1.1)(ws@8.20.0)
+        version: file:packages/connector-sqlite(js-yaml@4.1.1)(ws@8.20.1)
       '@ktx/connector-sqlserver':
         specifier: workspace:*
-        version: file:packages/connector-sqlserver(js-yaml@4.1.1)(ws@8.20.0)
+        version: file:packages/connector-sqlserver(js-yaml@4.1.1)(ws@8.20.1)
       '@ktx/context':
         specifier: workspace:*
         version: link:../context
@@ -441,7 +448,7 @@ importers:
         version: 6.0.180(zod@4.4.3)
       openai:
         specifier: ^6.37.0
-        version: 6.37.0(ws@8.20.0)(zod@4.4.3)
+        version: 6.37.0(ws@8.20.1)(zod@4.4.3)
     devDependencies:
       '@types/node':
         specifier: ^24.3.0
@@ -1242,7 +1249,7 @@ packages:
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: ^4
+      hono: 4.12.18
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -3087,8 +3094,8 @@ packages:
   brace-expansion@1.1.14:
     resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
 
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -3672,14 +3679,14 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fast-wrap-ansi@0.2.0:
     resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
 
-  fast-xml-builder@1.1.5:
-    resolution: {integrity: sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==}
+  fast-xml-builder@1.1.7:
+    resolution: {integrity: sha512-Yh7/7rQuMXICNr0oMYDR2yHP6oUvmQsTToFeOWj/kIDhAwQ+c4Ol/lbcwOmEM5OHYQmh6S6EQSQ1sljCKP36bQ==}
 
   fast-xml-parser@5.7.2:
     resolution: {integrity: sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==}
@@ -4061,8 +4068,8 @@ packages:
     resolution: {integrity: sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==}
     engines: {node: '>=0.10.0'}
 
-  hono@4.12.15:
-    resolution: {integrity: sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==}
+  hono@4.12.18:
+    resolution: {integrity: sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==}
     engines: {node: '>=16.9.0'}
 
   hook-std@4.0.0:
@@ -4187,8 +4194,8 @@ packages:
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
 
-  ip-address@10.1.0:
-    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+  ip-address@10.1.1:
+    resolution: {integrity: sha512-1FMu8/N15Ck1BL551Jf42NYIoin2unWjLQ2Fze/DXryJRl5twqtwNHlO39qERGbIOcKYWHdgRryhOC+NG4eaLw==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -5042,7 +5049,7 @@ packages:
     resolution: {integrity: sha512-0H5dEGFmmLv6KSd0W1w2nyL8WsLkX6yoLeQpU+dZAOuGcany5qkYQMmj35ZrKgb6yiyYqpUzFOpR8mZQkgqeEQ==}
     hasBin: true
     peerDependencies:
-      ws: ^8.18.0
+      ws: 8.20.1
       zod: ^3.25 || ^4.0
     peerDependenciesMeta:
       ws:
@@ -5240,12 +5247,8 @@ packages:
     resolution: {integrity: sha512-C+VUP+8jis7EsQZIhDYmS5qlNtjv2yP4SNtjXK9AP1ZcTRlnSfuumaTnRfYZnYgUUYVIKqL0fRvmUGDV2fmp6g==}
     engines: {node: '>=4'}
 
-  postcss@8.4.31:
-    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
-    engines: {node: ^10 || ^12 || >=14}
-
-  postcss@8.5.12:
-    resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
+  postcss@8.5.10:
+    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   postgres-array@2.0.0:
@@ -6173,8 +6176,8 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  ws@8.20.0:
-    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+  ws@8.20.1:
+    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -6282,8 +6285,8 @@ snapshots:
   '@ai-sdk/devtools@0.0.17':
     dependencies:
       '@ai-sdk/provider': 3.0.10
-      '@hono/node-server': 1.19.14(hono@4.12.15)
-      hono: 4.12.15
+      '@hono/node-server': 1.19.14(hono@4.12.18)
+      hono: 4.12.18
 
   '@ai-sdk/gateway@3.0.114(zod@4.4.3)':
     dependencies:
@@ -7550,9 +7553,9 @@ snapshots:
 
   '@google-cloud/promisify@5.0.0': {}
 
-  '@hono/node-server@1.19.14(hono@4.12.15)':
+  '@hono/node-server@1.19.14(hono@4.12.18)':
     dependencies:
-      hono: 4.12.15
+      hono: 4.12.18
 
   '@img/colour@1.1.0':
     optional: true
@@ -7672,10 +7675,10 @@ snapshots:
 
   '@js-joda/core@5.7.0': {}
 
-  '@ktx/connector-bigquery@file:packages/connector-bigquery(js-yaml@4.1.1)(ws@8.20.0)':
+  '@ktx/connector-bigquery@file:packages/connector-bigquery(js-yaml@4.1.1)(ws@8.20.1)':
     dependencies:
       '@google-cloud/bigquery': 8.3.1
-      '@ktx/context': file:packages/context(js-yaml@4.1.1)(ws@8.20.0)
+      '@ktx/context': file:packages/context(js-yaml@4.1.1)(ws@8.20.1)
     transitivePeerDependencies:
       - '@cfworker/json-schema'
       - js-yaml
@@ -7683,10 +7686,10 @@ snapshots:
       - supports-color
       - ws
 
-  '@ktx/connector-clickhouse@file:packages/connector-clickhouse(js-yaml@4.1.1)(ws@8.20.0)':
+  '@ktx/connector-clickhouse@file:packages/connector-clickhouse(js-yaml@4.1.1)(ws@8.20.1)':
     dependencies:
       '@clickhouse/client': 1.18.4
-      '@ktx/context': file:packages/context(js-yaml@4.1.1)(ws@8.20.0)
+      '@ktx/context': file:packages/context(js-yaml@4.1.1)(ws@8.20.1)
     transitivePeerDependencies:
       - '@cfworker/json-schema'
       - js-yaml
@@ -7694,9 +7697,9 @@ snapshots:
       - supports-color
       - ws
 
-  '@ktx/connector-mysql@file:packages/connector-mysql(@types/node@24.12.2)(js-yaml@4.1.1)(ws@8.20.0)':
+  '@ktx/connector-mysql@file:packages/connector-mysql(@types/node@24.12.2)(js-yaml@4.1.1)(ws@8.20.1)':
     dependencies:
-      '@ktx/context': file:packages/context(js-yaml@4.1.1)(ws@8.20.0)
+      '@ktx/context': file:packages/context(js-yaml@4.1.1)(ws@8.20.1)
       mysql2: 3.22.3(@types/node@24.12.2)
     transitivePeerDependencies:
       - '@cfworker/json-schema'
@@ -7706,9 +7709,9 @@ snapshots:
       - supports-color
       - ws
 
-  '@ktx/connector-postgres@file:packages/connector-postgres(js-yaml@4.1.1)(ws@8.20.0)':
+  '@ktx/connector-postgres@file:packages/connector-postgres(js-yaml@4.1.1)(ws@8.20.1)':
     dependencies:
-      '@ktx/context': file:packages/context(js-yaml@4.1.1)(ws@8.20.0)
+      '@ktx/context': file:packages/context(js-yaml@4.1.1)(ws@8.20.1)
       pg: 8.20.0
     transitivePeerDependencies:
       - '@cfworker/json-schema'
@@ -7717,9 +7720,9 @@ snapshots:
       - supports-color
       - ws
 
-  '@ktx/connector-snowflake@file:packages/connector-snowflake(asn1.js@5.4.1)(js-yaml@4.1.1)(ws@8.20.0)':
+  '@ktx/connector-snowflake@file:packages/connector-snowflake(asn1.js@5.4.1)(js-yaml@4.1.1)(ws@8.20.1)':
     dependencies:
-      '@ktx/context': file:packages/context(js-yaml@4.1.1)(ws@8.20.0)
+      '@ktx/context': file:packages/context(js-yaml@4.1.1)(ws@8.20.1)
       snowflake-sdk: 2.4.1(asn1.js@5.4.1)
     transitivePeerDependencies:
       - '@cfworker/json-schema'
@@ -7731,9 +7734,9 @@ snapshots:
       - supports-color
       - ws
 
-  '@ktx/connector-sqlite@file:packages/connector-sqlite(js-yaml@4.1.1)(ws@8.20.0)':
+  '@ktx/connector-sqlite@file:packages/connector-sqlite(js-yaml@4.1.1)(ws@8.20.1)':
     dependencies:
-      '@ktx/context': file:packages/context(js-yaml@4.1.1)(ws@8.20.0)
+      '@ktx/context': file:packages/context(js-yaml@4.1.1)(ws@8.20.1)
       better-sqlite3: 12.10.0
     transitivePeerDependencies:
       - '@cfworker/json-schema'
@@ -7742,9 +7745,9 @@ snapshots:
       - supports-color
       - ws
 
-  '@ktx/connector-sqlserver@file:packages/connector-sqlserver(js-yaml@4.1.1)(ws@8.20.0)':
+  '@ktx/connector-sqlserver@file:packages/connector-sqlserver(js-yaml@4.1.1)(ws@8.20.1)':
     dependencies:
-      '@ktx/context': file:packages/context(js-yaml@4.1.1)(ws@8.20.0)
+      '@ktx/context': file:packages/context(js-yaml@4.1.1)(ws@8.20.1)
       mssql: 12.5.2
     transitivePeerDependencies:
       - '@azure/core-client'
@@ -7780,10 +7783,10 @@ snapshots:
       - supports-color
       - ws
 
-  '@ktx/context@file:packages/context(js-yaml@4.1.1)(ws@8.20.0)':
+  '@ktx/context@file:packages/context(js-yaml@4.1.1)(ws@8.20.1)':
     dependencies:
       '@anthropic-ai/claude-agent-sdk': 0.3.142(zod@4.4.3)
-      '@ktx/llm': file:packages/llm(ws@8.20.0)(zod@4.4.3)
+      '@ktx/llm': file:packages/llm(ws@8.20.1)(zod@4.4.3)
       '@looker/sdk': 26.8.0
       '@looker/sdk-node': 26.8.0
       '@looker/sdk-rtl': 21.6.5
@@ -7806,13 +7809,13 @@ snapshots:
       - supports-color
       - ws
 
-  '@ktx/llm@file:packages/llm(ws@8.20.0)(zod@4.4.3)':
+  '@ktx/llm@file:packages/llm(ws@8.20.1)(zod@4.4.3)':
     dependencies:
       '@ai-sdk/anthropic': 3.0.77(zod@4.4.3)
       '@ai-sdk/devtools': 0.0.17
       '@ai-sdk/google-vertex': 4.0.128(zod@4.4.3)
       ai: 6.0.180(zod@4.4.3)
-      openai: 6.37.0(ws@8.20.0)(zod@4.4.3)
+      openai: 6.37.0(ws@8.20.1)(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
       - ws
@@ -7882,7 +7885,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.15)
+      '@hono/node-server': 1.19.14(hono@4.12.18)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -7892,7 +7895,7 @@ snapshots:
       eventsource-parser: 3.0.8
       express: 5.2.1
       express-rate-limit: 8.4.1(express@5.2.1)
-      hono: 4.12.15
+      hono: 4.12.18
       jose: 6.2.2
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -9128,7 +9131,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.3.0
       '@tailwindcss/oxide': 4.3.0
-      postcss: 8.5.12
+      postcss: 8.5.10
       tailwindcss: 4.3.0
 
   '@techteamer/ocsp@1.0.1':
@@ -9373,7 +9376,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -9520,7 +9523,7 @@ snapshots:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
 
@@ -10084,7 +10087,7 @@ snapshots:
   express-rate-limit@8.4.1(express@5.2.1):
     dependencies:
       express: 5.2.1
-      ip-address: 10.1.0
+      ip-address: 10.1.1
 
   express@5.2.1:
     dependencies:
@@ -10131,20 +10134,20 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fast-wrap-ansi@0.2.0:
     dependencies:
       fast-string-width: 3.0.2
 
-  fast-xml-builder@1.1.5:
+  fast-xml-builder@1.1.7:
     dependencies:
       path-expression-matcher: 1.5.0
 
   fast-xml-parser@5.7.2:
     dependencies:
       '@nodable/entities': 2.1.0
-      fast-xml-builder: 1.1.5
+      fast-xml-builder: 1.1.7
       path-expression-matcher: 1.5.0
       strnum: 2.2.3
 
@@ -10588,7 +10591,7 @@ snapshots:
     dependencies:
       parse-passwd: 1.0.0
 
-  hono@4.12.15: {}
+  hono@4.12.18: {}
 
   hook-std@4.0.0: {}
 
@@ -10715,7 +10718,7 @@ snapshots:
       type-fest: 5.6.0
       widest-line: 6.0.0
       wrap-ansi: 10.0.0
-      ws: 8.20.0
+      ws: 8.20.1
       yoga-layout: 3.2.1
     optionalDependencies:
       '@types/react': 19.2.14
@@ -10725,7 +10728,7 @@ snapshots:
 
   inline-style-parser@0.2.7: {}
 
-  ip-address@10.1.0: {}
+  ip-address@10.1.1: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -11520,7 +11523,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   minimatch@3.1.5:
     dependencies:
@@ -11619,7 +11622,7 @@ snapshots:
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.29
       caniuse-lite: 1.0.30001792
-      postcss: 8.4.31
+      postcss: 8.5.10
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
       styled-jsx: 5.1.6(react@19.2.6)
@@ -11734,9 +11737,9 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
-  openai@6.37.0(ws@8.20.0)(zod@4.4.3):
+  openai@6.37.0(ws@8.20.1)(zod@4.4.3):
     optionalDependencies:
-      ws: 8.20.0
+      ws: 8.20.1
       zod: 4.4.3
 
   openai@6.37.0(zod@4.4.3):
@@ -11946,13 +11949,7 @@ snapshots:
       find-up: 2.1.0
       load-json-file: 4.0.0
 
-  postcss@8.4.31:
-    dependencies:
-      nanoid: 3.3.11
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
-  postcss@8.5.12:
+  postcss@8.5.10:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -12938,7 +12935,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.12
+      postcss: 8.5.10
       rolldown: 1.0.0-rc.17
       tinyglobby: 0.2.16
     optionalDependencies:
@@ -13040,7 +13037,7 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  ws@8.20.0: {}
+  ws@8.20.1: {}
 
   wsl-utils@0.1.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,13 @@ packages:
 
 overrides:
   "@types/node": ^24.3.0
+  "brace-expansion@>=5.0.0 <5.0.6": 5.0.6
+  fast-uri: 3.1.2
+  fast-xml-builder: 1.1.7
+  hono: 4.12.18
+  ip-address: 10.1.1
+  postcss: 8.5.10
+  ws: 8.20.1
 
 dedupePeerDependents: false
 preferWorkspacePackages: true

--- a/uv.lock
+++ b/uv.lock
@@ -401,11 +401,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.13"
+version = "3.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
 ]
 
 [[package]]
@@ -1566,11 +1566,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add pnpm overrides for vulnerable transitive npm dependencies flagged by Dependabot
- refresh pnpm and uv lockfiles to patched versions, including idna and urllib3
- keep the diff limited to dependency metadata and lockfiles

## Verification
- pnpm audit --json
- pnpm run type-check
- pnpm run test
- pnpm --filter ktx-docs run build
- uv run pytest python/ktx-daemon/tests -q
- uv run pre-commit run --files pnpm-workspace.yaml pnpm-lock.yaml uv.lock
