### PR TITLE
fix: correct repository URL casing in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,10 +70,10 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/kaelio/ktx.git"
+    "url": "git+https://github.com/Kaelio/ktx.git"
   },
   "bugs": {
-    "url": "https://github.com/kaelio/ktx/issues"
+    "url": "https://github.com/Kaelio/ktx/issues"
   },
-  "homepage": "https://github.com/kaelio/ktx#readme"
+  "homepage": "https://github.com/Kaelio/ktx#readme"
 }


### PR DESCRIPTION
## Summary

`package.json` had `repository.url = git+https://github.com/kaelio/ktx.git` (lowercase), which makes git push targets hit a 301 redirect from `kaelio` → `Kaelio`. The redirect interacts badly with branch-protection actor evaluation (bypass list matches are lost). Pin the correct organization casing across `repository`, `bugs`, and `homepage`.

## Test plan

- [x] `git diff` shows only the three URL casing changes
- [ ] After merge: next release workflow push targets `https://github.com/Kaelio/ktx.git` directly, no redirect line in the log