### PR TITLE
ci(release): restore RELEASE_PAT for branch push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_PAT }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
@@ -93,7 +94,7 @@ jobs:
         if: ${{ !inputs.publish_live }}
         run: pnpm run semantic-release:dry-run
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
           KTX_RELEASE_KIND: ${{ inputs.release_kind }}
           FORCE_RELEASE: ${{ inputs.force_release }}
 
@@ -101,6 +102,6 @@ jobs:
         if: ${{ inputs.publish_live }}
         run: pnpm run semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
           KTX_RELEASE_KIND: ${{ inputs.release_kind }}
           FORCE_RELEASE: ${{ inputs.force_release }}

--- a/scripts/release-workflow.test.mjs
+++ b/scripts/release-workflow.test.mjs
@@ -31,6 +31,9 @@ describe('release workflow', () => {
     assert.match(workflow, /pnpm run semantic-release$/m);
     assert.match(workflow, /KTX_RELEASE_KIND: \$\{\{ inputs.release_kind \}\}/);
     assert.match(workflow, /FORCE_RELEASE: \$\{\{ inputs.force_release \}\}/);
+    assert.match(workflow, /token: \$\{\{ secrets.RELEASE_PAT \}\}/);
+    assert.match(workflow, /GITHUB_TOKEN: \$\{\{ secrets.RELEASE_PAT \}\}/);
+    assert.doesNotMatch(workflow, /GITHUB_TOKEN: \$\{\{ secrets\.GITHUB_TOKEN \}\}/);
     assert.doesNotMatch(workflow, /NODE_AUTH_TOKEN/);
     assert.doesNotMatch(workflow, /^  push:/m);
     assert.doesNotMatch(workflow, /^  pull_request:/m);


### PR DESCRIPTION
## Summary

Re-applies the RELEASE_PAT wiring on top of the URL-casing fix in #188. The default GITHUB_TOKEN identity (github-actions[bot]) cannot be added to bypass_pull_request_allowances, so the release workflow needs a PAT belonging to a user in the bypass list (RELEASE_PAT = andreybavt, confirmed via /user). With the canonical URL casing now in place, the PAT auth header survives all the way to the protected-branch hook.

## Test plan

- [x] `node --test scripts/release-workflow.test.mjs`
- [ ] After merge: trigger KTX Release workflow, expect git push to succeed and a `chore(release)` commit to land on main