### PR TITLE
ci: disable telemetry in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,11 @@ on:
 permissions:
   contents: read
 
+env:
+  DO_NOT_TRACK: "1"
+  KTX_TELEMETRY_DISABLED: "1"
+  NEXT_TELEMETRY_DISABLED: "1"
+
 concurrency:
   group: ktx-ci-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,11 @@ permissions:
   contents: write
   id-token: write
 
+env:
+  DO_NOT_TRACK: "1"
+  KTX_TELEMETRY_DISABLED: "1"
+  NEXT_TELEMETRY_DISABLED: "1"
+
 concurrency:
   group: ktx-release-${{ github.ref }}
   cancel-in-progress: false

--- a/.github/workflows/triage-issues.yml
+++ b/.github/workflows/triage-issues.yml
@@ -7,6 +7,11 @@ on:
 permissions:
   issues: write
 
+env:
+  DO_NOT_TRACK: "1"
+  KTX_TELEMETRY_DISABLED: "1"
+  NEXT_TELEMETRY_DISABLED: "1"
+
 jobs:
   label-external:
     name: Add needs-triage to external issues


### PR DESCRIPTION
## Summary

Disable telemetry for GitHub Actions workflows by setting workflow-level opt-out environment variables in CI, release, and issue triage jobs. This applies the supported ktx kill switch along with standard do-not-track and Next.js telemetry opt-outs so every job inherits the setting.

## Checks

- pre-commit hooks during commit
- node YAML parse for .github/workflows/*.yml