### PR TITLE
feat(cli): surface docs and demo-warehouse links in ktx setup

### DIFF
--- a/packages/cli/src/setup-databases.ts
+++ b/packages/cli/src/setup-databases.ts
@@ -35,6 +35,7 @@ import { isDemoConnection } from './telemetry/demo-detect.js';
 import { emitTelemetryEvent } from './telemetry/index.js';
 import {
   createKtxSetupPromptAdapter,
+  createKtxSetupUiAdapter,
   type KtxSetupPromptOption,
 } from './setup-prompts.js';
 
@@ -1780,6 +1781,11 @@ async function chooseDrivers(
     return 'missing-input';
   }
   const initialValues = unique(options?.initialDrivers ?? []);
+  createKtxSetupUiAdapter().note(
+    'Get demo credentials at https://kaelio.com/start',
+    '🎁 Need a warehouse to play with?',
+    io,
+  );
   const choices = await prompts.multiselect({
     message: withMultiselectNavigation('Which databases should KTX connect to?'),
     options: [...DRIVER_OPTIONS],

--- a/packages/cli/src/setup.ts
+++ b/packages/cli/src/setup.ts
@@ -586,6 +586,7 @@ export async function runKtxSetup(args: KtxSetupArgs, io: KtxCliIo, deps: KtxSet
 async function runKtxSetupInner(args: KtxSetupArgs, io: KtxCliIo, deps: KtxSetupDeps = {}): Promise<number> {
   const setupUi = deps.setupUi ?? createKtxSetupUiAdapter();
   setupUi.intro('KTX setup', io);
+  setupUi.note('https://docs.kaelio.com/ktx', '📚 Docs', io);
   let entryAction: KtxSetupEntryAction | undefined;
   let projectResult: Awaited<ReturnType<typeof runKtxSetupProjectStep>>;
   let agentNextActions: string | undefined;


### PR DESCRIPTION
## Summary

- Adds a Clack `note` with `https://docs.kaelio.com/ktx` (📚 Docs) right after the `KTX setup` intro, so the docs link is visible on the first screen of `ktx setup`.
- Adds a second Clack `note` with `https://kaelio.com/start` (🎁 Need a warehouse to play with?) above the database driver multiselect in `chooseDrivers`, mirroring the wording of the docs-site CTA at `docs-site/content/docs/getting-started/quickstart.mdx`.

Closes KLO-716 and KLO-715.

## Test plan

- [x] `pnpm --filter @kaelio/ktx run type-check`
- [x] `vitest run test/setup.test.ts test/setup-databases.test.ts test/setup-prompts.test.ts` — 120 passed
- [x] `uv run pre-commit run --files packages/cli/src/setup.ts packages/cli/src/setup-databases.ts`