### PR TITLE
feat(docs-site): redirect ktx.sh/slack to Slack community invite

### DIFF
--- a/docs-site/next.config.mjs
+++ b/docs-site/next.config.mjs
@@ -35,6 +35,14 @@ const config = {
         basePath: false,
       },
       {
+        source: "/slack",
+        has: [{ type: "host", value: "ktx.sh" }],
+        destination:
+          "https://join.slack.com/t/ktxcommunity/shared_invite/zt-3y9b44m1x-LVyNNJD5nwaZHq4XS29LMQ",
+        permanent: false,
+        basePath: false,
+      },
+      {
         source: "/:path*",
         has: [{ type: "host", value: "ktx.sh" }],
         destination: "https://docs.kaelio.com/ktx/:path*",


### PR DESCRIPTION
## Summary
- Add host-scoped redirect for `ktx.sh/slack` → Slack community invite, placed **before** the existing catch-all so it takes precedence.
- Without this, `/slack` falls through the catch-all and 308s to `https://docs.kaelio.com/ktx/slack`.
- 302 (not permanent) so the invite URL can be rotated later without browser cache pinning.

## Test plan
- [ ] Vercel preview deploy: `curl -I https://<preview-url>/slack` returns 302 to the Slack invite.
- [ ] After merge: `curl -I https://ktx.sh/slack` returns 302 to the Slack invite.
- [ ] `https://ktx.sh/anything-else` still redirects to `docs.kaelio.com/ktx/anything-else` (regression check).