### PR TITLE
ci: stop tombi reformatting uv.lock and sync lock to 0.7.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,12 @@ repos:
     hooks:
       - id: tombi-format
         args: ["--offline"]
+        # uv.lock is generated and owned by uv, which writes its own canonical
+        # TOML layout. tombi reformats that layout differently, so once uv
+        # regenerates the lock (e.g. after a dependency or version change)
+        # tombi rewrites it and the hook fails on the modified file. Keep uv
+        # authoritative for its lockfile; tombi still formats hand-edited TOML.
+        exclude: ^uv\.lock$
 
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.21.2

--- a/uv.lock
+++ b/uv.lock
@@ -466,7 +466,7 @@ wheels = [
 
 [[package]]
 name = "ktx-daemon"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "python/ktx-daemon" }
 dependencies = [
   { name = "fastapi" },
@@ -523,7 +523,7 @@ dev = [
 
 [[package]]
 name = "ktx-sl"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "python/ktx-sl" }
 dependencies = [
   { name = "pydantic" },


### PR DESCRIPTION
The `Pre-commit checks` CI job failed on the `tombi-format` hook because tombi reformats `uv.lock` to a layout that uv does not produce. CI's `uv sync` re-resolved the stale lock (workspace members were still pinned to `0.6.0` after the `0.7.0` release) and rewrote it in uv's canonical layout, then tombi rewrote it back and the hook reported a modified file. This PR excludes `uv.lock` from `tombi-format` so uv stays authoritative for its generated lockfile, and bumps `ktx-daemon`/`ktx-sl` to `0.7.0` so the lock is current and uv no longer re-resolves it. Verified locally: `uv run pre-commit run --all-files` exits 0 with all hooks passing and `uv lock --check` passes.