### PR TITLE
ci: fix star-history workflow push to protected main branch

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -25,6 +25,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # RELEASE_PAT can push to the protected main branch; the default
+          # GITHUB_TOKEN is rejected by the branch-protection hook (GH006).
+          token: ${{ secrets.RELEASE_PAT }}
 
       - name: Fetch fresh star-history SVG
         run: |


### PR DESCRIPTION
## Problem

The scheduled **Refresh star history chart** workflow ([run #26685405924](https://github.com/Kaelio/ktx-ai-data-agents-mcp-context-skills/actions/runs/26685405924/job/78652664977)) failed at the **Commit if changed** step:

```
remote: error: GH006: Protected branch update failed for refs/heads/main.
 ! [remote rejected] main -> main (protected branch hook declined)
```

The workflow checks out with the default `GITHUB_TOKEN`, then `git push`es the regenerated `assets/star-history.svg` directly to `main`. Because `main` is protected, the default token's push is rejected by the branch-protection hook.

## Fix

Check out with `secrets.RELEASE_PAT` so the persisted credential used by `git push` can write to the protected `main` branch.

This mirrors the existing pattern in `release.yml`, whose `@semantic-release/git` step already commits version bumps and changelog back to `main` using the same `RELEASE_PAT` — confirming that PAT is in the branch-protection bypass allowlist while the default `GITHUB_TOKEN` is not.

## Verification

- `RELEASE_PAT` confirmed present in repo secrets.
- Workflow YAML parses cleanly.
- The fix takes effect once merged, since the workflow runs on schedule from `main`.