### PR TITLE
feat(telemetry): enable PostHog GeoIP enrichment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -278,7 +278,7 @@ use `PascalCase` without the suffix.
 
 ## Telemetry
 
-**ktx** ships anonymous PostHog telemetry. When adding commands or events:
+**ktx** ships PostHog usage telemetry. When adding commands or events:
 
 - **MUST NOT**: Add fields that carry user data — file paths, hostnames,
   environment values, SQL text, schema/table/column names, error messages,

--- a/docs-site/content/docs/community/telemetry.mdx
+++ b/docs-site/content/docs/community/telemetry.mdx
@@ -1,9 +1,9 @@
 ---
 title: Telemetry
-description: Understand what anonymous usage telemetry ktx collects and how to opt out.
+description: Understand what usage telemetry ktx collects and how to opt out.
 ---
 
-**ktx** collects anonymous, aggregated usage telemetry so maintainers can see
+**ktx** collects aggregated usage telemetry so maintainers can see
 which commands work, where setup fails, and which parts of the data-agent
 workflow need improvement. Telemetry is opt-out: it turns on the first time you
 run **ktx** in an interactive terminal, which prints a one-time notice. From

--- a/packages/cli/src/telemetry/emitter.ts
+++ b/packages/cli/src/telemetry/emitter.ts
@@ -44,7 +44,7 @@ async function getPostHogClient(projectApiKey: string, host: string): Promise<Po
   }
 
   clientPromise ??= import('posthog-node')
-    .then(({ PostHog }) => new PostHog(projectApiKey, { host, flushAt: 1, flushInterval: 0 }))
+    .then(({ PostHog }) => new PostHog(projectApiKey, { host, flushAt: 1, flushInterval: 0, disableGeoip: false }))
     .catch(() => null);
 
   return await clientPromise;

--- a/packages/cli/src/telemetry/identity.ts
+++ b/packages/cli/src/telemetry/identity.ts
@@ -6,7 +6,7 @@ import { z } from 'zod';
 
 /** @internal */
 export const TELEMETRY_NOTICE =
-  'ktx collects anonymous usage data to improve the product. Opt out: set KTX_TELEMETRY_DISABLED=1.';
+  'ktx collects usage data to improve the product. Opt out: set KTX_TELEMETRY_DISABLED=1.';
 
 const NOTICE_VERSION = 1;
 


### PR DESCRIPTION
Enables PostHog GeoIP enrichment by setting `disableGeoip: false` on the CLI telemetry client, so events are enriched with approximate IP-based location at ingest. Updates the first-run notice, the public telemetry docs, and the AGENTS telemetry policy to drop the prior "anonymous" wording to match.