### PR TITLE
fix(release): point repository URLs at renamed GitHub repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -10,5 +10,5 @@ contact_links:
     url: https://docs.kaelio.com/ktx/docs/community/support
     about: Full guide on where to ask what — Slack vs. GitHub Issues vs. docs.
   - name: Security issues
-    url: https://github.com/Kaelio/ktx/security/advisories/new
+    url: https://github.com/Kaelio/ktx-ai-data-agents-context/security/advisories/new
     about: Report security vulnerabilities privately via GitHub Security Advisories. Please do not file security issues publicly.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,7 +212,7 @@ jobs:
         uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          slug: Kaelio/ktx
+          slug: Kaelio/ktx-ai-data-agents-context
           files: ./packages/cli/coverage/lcov.info
           flags: typescript
           name: typescript
@@ -231,7 +231,7 @@ jobs:
         uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          slug: Kaelio/ktx
+          slug: Kaelio/ktx-ai-data-agents-context
           files: ./coverage/python.xml
           flags: python
           name: python

--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -35,7 +35,7 @@ jobs:
           set -euo pipefail
           # cachebust forces star-history to regenerate instead of serving its
           # own server-side cache; --location follows the slug-normalizing 301.
-          url="https://api.star-history.com/svg?repos=Kaelio/ktx&type=Date&cachebust=${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          url="https://api.star-history.com/svg?repos=Kaelio/ktx-ai-data-agents-context&type=Date&cachebust=${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           curl --fail --location --silent --show-error \
             --retry 3 --retry-delay 5 --max-time 60 \
             -o assets/star-history.svg.new "$url"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -381,7 +381,8 @@ rather than silently skipping it.
 - **MUST**: Disable monospace ligatures on every surface that uses the
   `var(--font-mono)` family (Geist Mono). Geist Mono fuses `--` into an
   em-dash glyph that visually eats the adjacent space, so prompts like
-  `npx skills add Kaelio/ktx --skill ktx` render as `Kaelio/ktx--skill ktx`.
+  `npx skills add Kaelio/ktx-ai-data-agents-context --skill ktx` render as
+  `Kaelio/ktx-ai-data-agents-context--skill ktx`.
 - **MUST**: When adding a new container that renders user-visible monospace
   text outside `<code>` / `<pre>` (e.g. a styled `<div className="font-mono">`
   for a copyable prompt), verify the global ligature-off rule in

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,8 +8,8 @@ layout, and verification commands, see the
 ## How to contribute
 
 1. Browse open issues labeled
-   [`good first issue`](https://github.com/Kaelio/ktx/labels/good%20first%20issue)
-   or [`help wanted`](https://github.com/Kaelio/ktx/labels/help%20wanted).
+   [`good first issue`](https://github.com/Kaelio/ktx-ai-data-agents-context/labels/good%20first%20issue)
+   or [`help wanted`](https://github.com/Kaelio/ktx-ai-data-agents-context/labels/help%20wanted).
 2. Comment on the issue to claim it. A maintainer will confirm scope and
    assign it to you.
 3. For changes not covered by an existing issue, open one first so we can
@@ -82,7 +82,7 @@ page for the full guide. The short version:
 - **Feature requests**: use the
   [Feature request](.github/ISSUE_TEMPLATE/feature_request.yml) template.
 - **Security**: report privately via
-  [GitHub Security Advisories](https://github.com/Kaelio/ktx/security/advisories/new),
+  [GitHub Security Advisories](https://github.com/Kaelio/ktx-ai-data-agents-context/security/advisories/new),
   not as a public issue.
 
 ## Code of conduct

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@
 
 <p align="center">
   <a href="https://www.npmjs.com/package/@kaelio/ktx"><img src="https://img.shields.io/npm/v/@kaelio/ktx?style=flat-square&color=f97316" alt="npm version" /></a>
-  <a href="https://codecov.io/gh/Kaelio/ktx"><img src="https://codecov.io/gh/Kaelio/ktx/graph/badge.svg?branch=main" alt="Codecov" /></a>
-  <a href="https://github.com/Kaelio/ktx/actions/workflows/ci.yml?query=branch%3Amain"><img src="https://img.shields.io/github/actions/workflow/status/Kaelio/ktx/ci.yml?branch=main&label=tests&style=flat-square" alt="Tests" /></a>
+  <a href="https://codecov.io/gh/Kaelio/ktx-ai-data-agents-context"><img src="https://codecov.io/gh/Kaelio/ktx-ai-data-agents-context/graph/badge.svg?branch=main" alt="Codecov" /></a>
+  <a href="https://github.com/Kaelio/ktx-ai-data-agents-context/actions/workflows/ci.yml?query=branch%3Amain"><img src="https://img.shields.io/github/actions/workflow/status/Kaelio/ktx-ai-data-agents-context/ci.yml?branch=main&label=tests&style=flat-square" alt="Tests" /></a>
   <a href="https://docs.kaelio.com/ktx/docs/"><img src="https://img.shields.io/badge/docs-ktx-22c55e?style=flat-square" alt="Documentation" /></a>
   <a href="https://join.slack.com/t/ktxcommunity/shared_invite/zt-3y9b44m1x-LVyNNJD5nwaZHq4XS29LMQ"><img src="https://img.shields.io/badge/slack-join%20community-4A154B?style=flat-square&logo=slack&logoColor=white" alt="Join the ktx Slack community" /></a>
-  <a href="https://github.com/Kaelio/ktx/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="License" /></a>
+  <a href="https://github.com/Kaelio/ktx-ai-data-agents-context/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="License" /></a>
   <a href="https://www.ycombinator.com/companies?batch=P25"><img src="https://img.shields.io/badge/Y%20Combinator-P25-orange?style=flat-square" alt="Y Combinator P25" /></a>
 </p>
 
@@ -130,7 +130,7 @@ Agent integration ready: yes (codex:project)
 > your project directory:
 >
 > ```text
-> Run npx skills add Kaelio/ktx --skill ktx and use the ktx skill to install
+> Run npx skills add Kaelio/ktx-ai-data-agents-context --skill ktx and use the ktx skill to install
 > and configure ktx in this project.
 > ```
 
@@ -201,7 +201,7 @@ then the current directory. Pass `--project-dir <path>` when scripting.
 ## Community
 
 - **[Slack](https://join.slack.com/t/ktxcommunity/shared_invite/zt-3y9b44m1x-LVyNNJD5nwaZHq4XS29LMQ)** — ask questions, share what you're building, and chat with maintainers.
-- **[GitHub Issues](https://github.com/Kaelio/ktx/issues)** — report bugs and request features.
+- **[GitHub Issues](https://github.com/Kaelio/ktx-ai-data-agents-context/issues)** — report bugs and request features.
 - **[Contributing](https://docs.kaelio.com/ktx/docs/community/contributing)** — set up the repo, run tests, and open a PR.
 
 ## Development
@@ -258,7 +258,7 @@ event catalog and opt-out options.
 ## Star History
 
 <p align="center">
-  <a href="https://star-history.com/#Kaelio/ktx&Date">
+  <a href="https://star-history.com/#Kaelio/ktx-ai-data-agents-context&Date">
     <img src="assets/star-history.svg" alt="ktx Star History Chart" width="700" />
   </a>
 </p>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,7 +5,7 @@
 If you believe you've found a security vulnerability in KTX, please report it
 **privately** through GitHub Security Advisories:
 
-[Report a vulnerability](https://github.com/Kaelio/ktx/security/advisories/new)
+[Report a vulnerability](https://github.com/Kaelio/ktx-ai-data-agents-context/security/advisories/new)
 
 If you cannot use GitHub Security Advisories, email `support@kaelio.com`
 instead. Please do **not** open a public issue, post in the KTX Slack, or

--- a/docs-site/content/docs/ai-resources/prompt-recipes.mdx
+++ b/docs-site/content/docs/ai-resources/prompt-recipes.mdx
@@ -14,7 +14,7 @@ Read https://docs.kaelio.com/ktx/llms.txt first. Then fetch only the ktx Markdow
 ## Set up a project
 
 ```text
-Run npx skills add Kaelio/ktx --skill ktx and use the ktx skill to install
+Run npx skills add Kaelio/ktx-ai-data-agents-context --skill ktx and use the ktx skill to install
 and configure ktx in this project.
 ```
 

--- a/docs-site/content/docs/community/support.mdx
+++ b/docs-site/content/docs/community/support.mdx
@@ -11,7 +11,7 @@ the core team trade questions, share patterns, and shape the roadmap.
 | You want to... | Go here |
 |----------------|---------|
 | Ask a question or chat with the community | [**ktx** Slack](https://join.slack.com/t/ktxcommunity/shared_invite/zt-3y9b44m1x-LVyNNJD5nwaZHq4XS29LMQ) |
-| Report a bug or request a feature | [GitHub Issues](https://github.com/Kaelio/ktx/issues) |
+| Report a bug or request a feature | [GitHub Issues](https://github.com/Kaelio/ktx-ai-data-agents-context/issues) |
 | Read or contribute to the docs | [docs.kaelio.com/ktx](https://docs.kaelio.com/ktx/docs/) |
 | Contribute code | [Contributing guide](/docs/community/contributing) |
 
@@ -30,14 +30,14 @@ Slack is the right place for:
 - **Feedback** on the roadmap and early features
 
 For anything reproducible - a crash, a wrong result, an unexpected CLI error -
-open a [GitHub issue](https://github.com/Kaelio/ktx/issues) instead. Issues are
+open a [GitHub issue](https://github.com/Kaelio/ktx-ai-data-agents-context/issues) instead. Issues are
 searchable, get triaged, and stay attached to the eventual fix.
 
 ## GitHub
 
-- **[Issues](https://github.com/Kaelio/ktx/issues)** - bugs and feature requests
-- **[Pull requests](https://github.com/Kaelio/ktx/pulls)** - code, docs, and connector contributions
-- **[Releases](https://github.com/Kaelio/ktx/releases)** - changelog and published versions
+- **[Issues](https://github.com/Kaelio/ktx-ai-data-agents-context/issues)** - bugs and feature requests
+- **[Pull requests](https://github.com/Kaelio/ktx-ai-data-agents-context/pulls)** - code, docs, and connector contributions
+- **[Releases](https://github.com/Kaelio/ktx-ai-data-agents-context/releases)** - changelog and published versions
 
 ## Code of conduct
 

--- a/docs-site/content/docs/getting-started/introduction.mdx
+++ b/docs-site/content/docs/getting-started/introduction.mdx
@@ -102,6 +102,6 @@ best first step for users; contributor setup lives in the community docs.
 Have questions, want to share what you're building, or chat with maintainers?
 Join the [**ktx** Slack community](https://join.slack.com/t/ktxcommunity/shared_invite/zt-3y9b44m1x-LVyNNJD5nwaZHq4XS29LMQ).
 For bug reports and feature requests, open a
-[GitHub issue](https://github.com/Kaelio/ktx/issues). See
+[GitHub issue](https://github.com/Kaelio/ktx-ai-data-agents-context/issues). See
 [Community & Support](/docs/community/support) for the full guide on where to
 ask what.

--- a/docs-site/content/docs/getting-started/quickstart.mdx
+++ b/docs-site/content/docs/getting-started/quickstart.mdx
@@ -171,14 +171,14 @@ If you're a coding assistant choosing a docs route, start with the
       </span>
       <CopyButton
         text={[
-          'Run npx skills add Kaelio/ktx --skill ktx and use the ktx skill',
+          'Run npx skills add Kaelio/ktx-ai-data-agents-context --skill ktx and use the ktx skill',
           'to install and configure ktx',
         ].join(' ')}
         className="-my-1"
       />
     </div>
     <div className="p-3 font-mono text-[13.5px] leading-6 text-fd-foreground">
-      Run {'`npx skills add Kaelio/ktx --skill ktx`'} and use the ktx skill to install and configure ktx
+      Run {'`npx skills add Kaelio/ktx-ai-data-agents-context --skill ktx`'} and use the ktx skill to install and configure ktx
     </div>
   </div>
 </div>

--- a/docs-site/lib/llm-docs.ts
+++ b/docs-site/lib/llm-docs.ts
@@ -52,7 +52,7 @@ ktx provides semantic-layer files, warehouse scans, wiki pages, provenance, and 
 
 ## Agent Entry Points
 
-- Installable setup skill: run \`npx skills add Kaelio/ktx --skill ktx\` from
+- Installable setup skill: run \`npx skills add Kaelio/ktx-ai-data-agents-context --skill ktx\` from
   the project you want to configure.
 ${link("/docs/ai-resources/agent-quickstart", "Agent Quickstart", "Task-first route for coding assistants using ktx")}
 ${link("/docs/ai-resources/markdown-access", "Markdown Access", "Fetch ktx docs as llms.txt, llms-full.txt, or per-page Markdown")}

--- a/docs/release.md
+++ b/docs/release.md
@@ -26,7 +26,7 @@ The workflow rejects releases from any branch other than `main`.
 Before you publish, confirm these requirements:
 
 - npm Trusted Publishing is configured for `@kaelio/ktx`.
-- The trusted publisher points at the `Kaelio/ktx` repository and the
+- The trusted publisher points at the `Kaelio/ktx-ai-data-agents-context` repository and the
   `.github/workflows/release.yml` workflow.
 - The workflow keeps `id-token: write` permission so npm can verify the
   GitHub Actions run through OpenID Connect.

--- a/docs/release.md
+++ b/docs/release.md
@@ -35,6 +35,15 @@ Before you publish, confirm these requirements:
 - The repository has a stable baseline tag when you need semantic-release to
   publish the first stable version as `0.1.0`.
 
+If you rename the GitHub repository, the semantic-release run adapts on its
+own: `scripts/semantic-release-config.cjs` derives `repositoryUrl` from the
+runner's `GITHUB_REPOSITORY`, so `@semantic-release/github` always matches the
+current clone URL. The one thing that does **not** auto-update is the npm
+Trusted Publishing config — re-point it at the new repository name (plus
+`release.yml`) on npm, or `npm publish --provenance` will fail OIDC
+verification. The `repository` field in `package.json` is npm-display metadata
+only and can stay whatever public name you prefer.
+
 semantic-release doesn't support choosing an arbitrary first `0.x` stable
 release. If KTX has no stable tag yet and you need the first stable release to
 be `0.1.0`, create and push the baseline tag once before running the live

--- a/package.json
+++ b/package.json
@@ -76,10 +76,10 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Kaelio/ktx.git"
+    "url": "git+https://github.com/Kaelio/ktx-ai-data-agents-context.git"
   },
   "bugs": {
-    "url": "https://github.com/Kaelio/ktx/issues"
+    "url": "https://github.com/Kaelio/ktx-ai-data-agents-context/issues"
   },
-  "homepage": "https://github.com/Kaelio/ktx#readme"
+  "homepage": "https://github.com/Kaelio/ktx-ai-data-agents-context#readme"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -93,11 +93,11 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Kaelio/ktx",
+    "url": "https://github.com/Kaelio/ktx-ai-data-agents-context",
     "directory": "packages/cli"
   },
   "bugs": {
-    "url": "https://github.com/Kaelio/ktx/issues"
+    "url": "https://github.com/Kaelio/ktx-ai-data-agents-context/issues"
   },
-  "homepage": "https://github.com/Kaelio/ktx#readme"
+  "homepage": "https://github.com/Kaelio/ktx-ai-data-agents-context#readme"
 }

--- a/scripts/semantic-release-config.cjs
+++ b/scripts/semantic-release-config.cjs
@@ -104,6 +104,22 @@ function releaseTag(kind, env = process.env) {
   return `branch-${branchPrereleaseId(branchName)}`;
 }
 
+function repositoryUrl(env = process.env) {
+  // @semantic-release/github compares this URL's owner/repo against the live
+  // GitHub clone_url with an exact match (no redirect following), so a repo
+  // rename breaks the release unless repositoryUrl tracks the *current* name.
+  // In CI, derive it from the runner's repository so renames never re-break the
+  // release. Outside CI, return undefined so semantic-release falls back to the
+  // package.json `repository` field (its documented default).
+  const repository = env.GITHUB_REPOSITORY;
+  if (!repository) {
+    return undefined;
+  }
+
+  const server = env.GITHUB_SERVER_URL || 'https://github.com';
+  return `${server}/${repository}.git`;
+}
+
 function releaseBranches(env = process.env) {
   const kind = releaseKind(env);
 
@@ -127,10 +143,12 @@ function releaseBranches(env = process.env) {
 function createReleaseConfig(env = process.env) {
   const kind = releaseKind(env);
   const tag = releaseTag(kind, env);
+  const url = repositoryUrl(env);
 
   return {
     tagFormat: 'v${version}',
     branches: releaseBranches(env),
+    ...(url ? { repositoryUrl: url } : {}),
     plugins: [
       [
         '@semantic-release/commit-analyzer',
@@ -203,4 +221,5 @@ module.exports = {
   releaseBranches,
   releaseKind,
   releaseTag,
+  repositoryUrl,
 };

--- a/scripts/semantic-release-config.test.mjs
+++ b/scripts/semantic-release-config.test.mjs
@@ -3,7 +3,7 @@ import { createRequire } from 'node:module';
 import { describe, it } from 'node:test';
 
 const require = createRequire(import.meta.url);
-const { createReleaseConfig, releaseBranches, releaseKind, releaseTag } = require('./semantic-release-config.cjs');
+const { createReleaseConfig, releaseBranches, releaseKind, releaseTag, repositoryUrl } = require('./semantic-release-config.cjs');
 
 function prepareExecOptions(config) {
   return config.plugins.find((plugin) => Array.isArray(plugin) && plugin[0] === '@semantic-release/exec' && plugin[1].prepareCmd)[1];
@@ -139,6 +139,38 @@ describe('semantic-release config', () => {
       (plugin) => Array.isArray(plugin) && plugin[0] === '@semantic-release/exec' && plugin[1].analyzeCommitsCmd,
     );
     assert.match(analyzeExec[1].analyzeCommitsCmd, /FORCE_RELEASE === 'true' \? 'patch' : ''/);
+  });
+
+  it('pins repositoryUrl to the runner repository so a GitHub rename never re-breaks the release', () => {
+    // @semantic-release/github exact-matches repositoryUrl against the live
+    // clone_url, so the release must track the *current* repo name, not the
+    // static package.json value.
+    assert.equal(
+      repositoryUrl({ GITHUB_REPOSITORY: 'Kaelio/ktx-ai-data-agents-context' }),
+      'https://github.com/Kaelio/ktx-ai-data-agents-context.git',
+    );
+    assert.equal(
+      repositoryUrl({ GITHUB_REPOSITORY: 'Kaelio/ktx' }),
+      'https://github.com/Kaelio/ktx.git',
+      'a later rename back to Kaelio/ktx must resolve without any code change',
+    );
+    assert.equal(
+      repositoryUrl({ GITHUB_REPOSITORY: 'Kaelio/ktx', GITHUB_SERVER_URL: 'https://ghe.example.com' }),
+      'https://ghe.example.com/Kaelio/ktx.git',
+    );
+
+    const config = createReleaseConfig({
+      KTX_RELEASE_KIND: 'stable',
+      GITHUB_REF_NAME: 'main',
+      GITHUB_REPOSITORY: 'Kaelio/ktx-ai-data-agents-context',
+    });
+    assert.equal(config.repositoryUrl, 'https://github.com/Kaelio/ktx-ai-data-agents-context.git');
+  });
+
+  it('omits repositoryUrl outside CI so semantic-release falls back to package.json', () => {
+    assert.equal(repositoryUrl({}), undefined);
+    const config = createReleaseConfig({ KTX_RELEASE_KIND: 'stable', GITHUB_REF_NAME: 'main' });
+    assert.equal('repositoryUrl' in config, false);
   });
 
   it('does not configure any commit type to create an automatic major release', () => {


### PR DESCRIPTION
## Problem

The **KTX Release** workflow fails at the **Create semantic release** step:

```
EMISMATCHGITHUBURL The git repository URL mismatches the GitHub URL.
Your configuration for the repositoryUrl option is https://github.com/Kaelio/ktx.git
and the clone_url of your GitHub repo is https://github.com/Kaelio/ktx-ai-data-agents-context.git.
```

(failing run: https://github.com/Kaelio/ktx-ai-data-agents-context/actions/runs/26770957406/job/78909987896)

The GitHub repository was renamed from `Kaelio/ktx` to `Kaelio/ktx-ai-data-agents-context`. `@semantic-release/github` parses owner/repo from `repositoryUrl` (which defaults to `package.json`'s `repository` field) and **exact-matches** it against the repo's live `clone_url` — it does not follow GitHub's redirect. The stale `package.json` value broke `verifyConditions`.

## Fix

Two parts:

**1. Point references at the renamed repo.** Update every `Kaelio/ktx` reference to `Kaelio/ktx-ai-data-agents-context`: package metadata (`repository`/`bugs`/`homepage` in root + CLI `package.json`), codecov upload slugs and star-history slug in CI, issue-template/security links, README badges + links, docs-site, the release runbook, and the `npx skills add …` install commands. Web links and `git clone` references would also work via GitHub's 301, but pinning them to the canonical name avoids redirect reliance.

**2. Make the release immune to future renames.** `scripts/semantic-release-config.cjs` now derives `repositoryUrl` from the runner's `GITHUB_REPOSITORY`/`GITHUB_SERVER_URL`, so the `@semantic-release/github` match always tracks the *current* repo name. A future rename (including back to `Kaelio/ktx`) resolves with **zero code changes**. Outside CI the option is omitted, so semantic-release falls back to `package.json` as documented. The `package.json` `repository` field stays `ktx-ai-data-agents-context` as npm-display metadata, now decoupled from the release-time match.

No behavior changes beyond URLs/slugs and the release-config derivation. Added unit tests for `repositoryUrl` across current-name / renamed-back / GHE / local cases. `node --test scripts/semantic-release-config.test.mjs` passes (12 tests); all pre-commit hooks pass.

## ⚠️ One external follow-up on any rename

The **npm Trusted Publishing** config for `@kaelio/ktx` must point at the current repo name + `release.yml`. GitHub OIDC reports the current repo slug, so `npm publish --provenance` will fail OIDC verification until npm's trusted-publisher setting matches. This is on npmjs.com and can't be changed from the repo (documented in `docs/release.md`).