### PR TITLE
docs fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <a href="https://docs.kaelio.com/ktx/docs/"><img src="https://img.shields.io/badge/docs-ktx-22c55e?style=flat-square" alt="Documentation" /></a>
   <a href="https://join.slack.com/t/ktxcommunity/shared_invite/zt-3y9b44m1x-LVyNNJD5nwaZHq4XS29LMQ"><img src="https://img.shields.io/badge/slack-join%20community-4A154B?style=flat-square&logo=slack&logoColor=white" alt="Join the ktx Slack community" /></a>
   <a href="https://github.com/Kaelio/ktx/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="License" /></a>
-  <a href="https://www.ycombinator.com/companies?batch=P25"><img src="https://img.shields.io/badge/Y%20Combinator-P25-orange?style=flat-square" alt="Y Combinator P25" /></a>
+  <a href="https://www.ycombinator.com/companies/kaelio"><img src="https://img.shields.io/badge/Y%20Combinator-P25-orange?style=flat-square" alt="Y Combinator P25" /></a>
 </p>
 
 <p align="center">
@@ -21,6 +21,10 @@
   <a href="https://docs.kaelio.com/ktx/docs/cli-reference/ktx"><b>CLI Reference</b></a> ·
   <a href="https://docs.kaelio.com/ktx/docs/ai-resources/agent-quickstart"><b>Agent Setup</b></a> ·
   <a href="https://join.slack.com/t/ktxcommunity/shared_invite/zt-3y9b44m1x-LVyNNJD5nwaZHq4XS29LMQ"><b>Slack</b></a>
+</p>
+
+<p align="center">
+  <sub>Built and maintained by <a href="https://www.kaelio.com"><b>Kaelio</b></a></sub>
 </p>
 
 ---

--- a/docs-site/app/layout.config.tsx
+++ b/docs-site/app/layout.config.tsx
@@ -5,7 +5,7 @@ import { SlackIcon } from "@/components/slack-icon";
 
 export const baseOptions: BaseLayoutProps = {
   nav: {
-    title: <Logo />,
+    title: Logo,
     transparentMode: "top",
   },
   links: [

--- a/docs-site/components/logo.tsx
+++ b/docs-site/components/logo.tsx
@@ -1,40 +1,56 @@
-export function Logo() {
+"use client";
+
+import Link from "next/link";
+
+const brandFont = {
+  fontFamily: "var(--font-display), var(--font-sans), sans-serif",
+} as const;
+
+export function Logo({ href = "/", className }: { href?: string; className?: string }) {
   return (
-    <div className="flex items-center gap-3.5 group">
-      <div className="relative flex items-center justify-center transition-transform duration-300 ease-out group-hover:rotate-[-4deg]">
-        <img
-          src="/ktx/brand/ktx-mascot.svg"
-          alt=""
-          aria-hidden="true"
-          className="h-20 w-20 object-contain block dark:hidden"
-        />
-        <img
-          src="/ktx/brand/ktx-mascot-dark.svg"
-          alt=""
-          aria-hidden="true"
-          className="h-20 w-20 object-contain hidden dark:block"
-        />
-      </div>
-      <div className="flex flex-col items-start leading-none">
+    <div className={className}>
+      <div className="flex items-center gap-3.5 group">
+        <Link href={href} aria-label="ktx documentation home" className="flex items-center no-underline">
+          <span className="relative flex items-center justify-center transition-transform duration-300 ease-out group-hover:rotate-[-4deg]">
+            <img
+              src="/ktx/brand/ktx-mascot.svg"
+              alt=""
+              aria-hidden="true"
+              className="h-20 w-20 object-contain block dark:hidden"
+            />
+            <img
+              src="/ktx/brand/ktx-mascot-dark.svg"
+              alt=""
+              aria-hidden="true"
+              className="h-20 w-20 object-contain hidden dark:block"
+            />
+          </span>
+        </Link>
+        <div className="flex flex-col items-start leading-none">
+          <Link
+            href={href}
+            className="text-[42px] font-semibold text-fd-foreground tracking-tight no-underline"
+            style={brandFont}
+          >
+            ktx
+          </Link>
+          <a
+            href="https://www.kaelio.com"
+            target="_blank"
+            rel="noreferrer"
+            className="mt-1 whitespace-nowrap text-[13px] font-medium text-fd-muted-foreground/80 tracking-tight no-underline transition-colors hover:text-fd-foreground"
+            style={brandFont}
+          >
+            by Kaelio
+          </a>
+        </div>
         <span
-          className="text-[42px] font-semibold text-fd-foreground tracking-tight"
-          style={{ fontFamily: "var(--font-display), var(--font-sans), sans-serif" }}
+          className="text-[19px] font-medium text-fd-muted-foreground/80 tracking-tight border-l border-fd-border pl-3 ml-1"
+          style={brandFont}
         >
-          ktx
-        </span>
-        <span
-          className="mt-1 whitespace-nowrap text-[13px] font-medium text-fd-muted-foreground/80 tracking-tight"
-          style={{ fontFamily: "var(--font-display), var(--font-sans), sans-serif" }}
-        >
-          by Kaelio
+          Docs
         </span>
       </div>
-      <span
-        className="text-[19px] font-medium text-fd-muted-foreground/80 tracking-tight border-l border-fd-border pl-3 ml-1"
-        style={{ fontFamily: "var(--font-display), var(--font-sans), sans-serif" }}
-      >
-        Docs
-      </span>
     </div>
   );
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -2,6 +2,10 @@
   "name": "@kaelio/ktx",
   "version": "0.9.0",
   "description": "Standalone ktx context layer for data agents",
+  "author": {
+    "name": "Kaelio",
+    "url": "https://www.kaelio.com"
+  },
   "type": "module",
   "engines": {
     "node": ">=22.0.0"


### PR DESCRIPTION
Small README and docs-site touch-ups:

- Link the Y Combinator badge to the company profile
- Make the docs nav "by Kaelio" label a link
- Add a maintainer line to the README
- Set the npm `author` field on `@kaelio/ktx`

Docs-site verified locally (page renders `200`, no console errors); `author` is purely additive and doesn't affect the release pipeline (version-bump preserves it, runtime reads only `name`/`version`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)