### PR TITLE
docs(site): add Products dropdown to ktx docs navbar

### DIFF
--- a/docs-site/app/layout.config.tsx
+++ b/docs-site/app/layout.config.tsx
@@ -10,6 +10,23 @@ export const baseOptions: BaseLayoutProps = {
   },
   links: [
     {
+      type: "menu",
+      text: "Products",
+      items: [
+        {
+          text: "ktx",
+          description: "The ktx CLI & toolkit docs",
+          url: "/docs",
+        },
+        {
+          text: "Kaelio Platform",
+          description: "Docs for the Kaelio platform",
+          url: "https://docs.kaelio.com/agent/docs",
+          external: true,
+        },
+      ],
+    },
+    {
       type: "icon",
       label: "GitHub",
       icon: <GitHubIcon />,


### PR DESCRIPTION
## What
Adds a **Products** dropdown to the ktx docs navbar (`docs-site/app/layout.config.tsx`), letting users switch between:
- **ktx** → `/docs` (primary product, current site, listed first)
- **Kaelio Platform** → https://docs.kaelio.com/agent/docs

## Why
Mirrors the product switcher on the Kaelio docs side so the two docs sites cross-link. ktx stays the favored/default product (listed first, default landing unchanged).

## Notes
- Uses Fumadocs' built-in `type: 'menu'` link (renders as navbar dropdown + mobile menu).
- Companion PR in Kaelio/kaelio adds the mirror dropdown on the Kaelio side.
- Passes `tsc --noEmit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)