### PR TITLE
docs: remove product switcher from docs nav

### DIFF
--- a/docs-site/app/layout.config.tsx
+++ b/docs-site/app/layout.config.tsx
@@ -9,23 +9,6 @@ export const baseOptions: BaseLayoutProps = {
   },
   links: [
     {
-      type: "menu",
-      text: "Products",
-      items: [
-        {
-          text: "ktx",
-          description: "The ktx CLI & toolkit docs",
-          url: "/docs",
-        },
-        {
-          text: "Kaelio Platform",
-          description: "Docs for the Kaelio platform",
-          url: "https://docs.kaelio.com/agent/docs",
-          external: true,
-        },
-      ],
-    },
-    {
       type: "icon",
       label: "Join the ktx Slack community",
       icon: <SlackIcon />,


### PR DESCRIPTION
## What

Removes the **Products** dropdown from the docs-site nav (`docs-site/app/layout.config.tsx`). The nav now carries only the Slack link.

## Why

The dropdown listed two co-equal entries — **ktx** and the legacy **Kaelio Platform** (agent product). On the ktx docs, a product *switcher* is the wrong pattern: it framed ktx as one of two products and gave the unrelated legacy product equal billing, making visitors who were already on the right page second-guess it. We paid that positioning cost on every ktx visitor to serve a few legacy ones.

Cross-product discovery belongs at the `docs.kaelio.com` apex (a domain-level concern shared by the two separate doc deployments), not inside the ktx nav.

## Not in this PR / follow-ups

- **Apex behavior unchanged.** `docs.kaelio.com/` still auto-redirects to ktx via the `source: "/"` rule in `docs-site/next.config.mjs:63-68`. If a top-level chooser ("ktx vs agent platform") is built at the apex, that redirect should be revisited so the two stop fighting over `/`.
- **Legacy link path discrepancy.** The removed link pointed at `docs.kaelio.com/agent/docs`, but the legacy product reportedly lives at `docs.kaelio.com/agents`. Worth confirming the correct path before it lands in any future chooser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)