### PR TITLE
docs: align introduction subtitle width with page content

### DIFF
--- a/docs-site/content/docs/getting-started/introduction.mdx
+++ b/docs-site/content/docs/getting-started/introduction.mdx
@@ -24,7 +24,7 @@ import { ProductRuntime } from "@/components/product-runtime";
     >
       Make analytics context usable by agents
     </h1>
-    <p className="mt-4 max-w-2xl text-lg text-fd-muted-foreground" style={{ lineHeight: '1.7' }}>
+    <p className="mt-4 max-w-full text-lg text-fd-muted-foreground" style={{ lineHeight: '1.7' }}>
       {'ktx is an open-source context layer for data agents. It turns warehouse metadata, BI tool definitions, query history, docs, and approved metric definitions into reviewable files agents can search and execute.'}
     </p>
   </div>


### PR DESCRIPTION
## What

Widen the introduction page subtitle from `max-w-2xl` to `max-w-full` so it spans the same content column as the heading and body.

## Why

The `getting-started/introduction` page is special-cased as a "hero" in `app/docs/[[...slug]]/page.tsx` — it skips Fumadocs' default `DocsTitle`/`DocsDescription` and hand-rolls its own `<h1>` + `<p>`. The heading uses `max-w-full`, but the subtitle was capped at `max-w-2xl` (672px), wrapping ~230px narrower than the heading and the body below it. Every other docs page renders its subtitle through `<DocsDescription>`, which fills the full column, so the introduction subtitle looked misaligned by comparison.

## Before / after

The subtitle now wraps at the same edge as the heading and paragraphs, matching the alignment of all other docs pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)