### PR TITLE
fix(cli): initialize nested ktx projects as git roots

### DIFF
--- a/packages/cli/src/context/core/git.service.ts
+++ b/packages/cli/src/context/core/git.service.ts
@@ -1,6 +1,6 @@
 import { promises as fs } from 'node:fs';
 import { dirname, join } from 'node:path';
-import type { SimpleGit } from 'simple-git';
+import { CheckRepoActions, type SimpleGit } from 'simple-git';
 import { noopLogger, resolveConfigDir, type KtxCoreConfig, type KtxLogger } from './config.js';
 import { createSimpleGit } from './git-env.js';
 
@@ -98,10 +98,15 @@ export class GitService {
 
   private async initialize(): Promise<void> {
     try {
-      // Check if already initialized
-      const isRepo = await this.git.checkIsRepo();
+      // Adopt an existing repo ONLY when this directory is itself that repo's root.
+      // When it sits below an enclosing repo, a plain checkIsRepo() is true and ktx
+      // would silently piggyback on the enclosing tree — but every ktx relative path
+      // (file-store writes, session worktrees, squash-merges, reindex scans) assumes
+      // this directory IS the working-tree root. So treat "inside an enclosing repo"
+      // the same as "no repo" and initialize a dedicated repo rooted here.
+      const isRepoRoot = await this.git.checkIsRepo(CheckRepoActions.IS_REPO_ROOT);
 
-      if (!isRepo) {
+      if (!isRepoRoot) {
         await this.git.init();
         this.logger.log('Initialized git repository');
       }

--- a/packages/cli/test/context/index-sync/reindex.nested-git-root.test.ts
+++ b/packages/cli/test/context/index-sync/reindex.nested-git-root.test.ts
@@ -1,0 +1,66 @@
+import { execFileSync } from 'node:child_process';
+import { mkdir, mkdtemp, rm, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { reindexLocalIndexes } from '../../../src/context/index-sync/reindex.js';
+import { initKtxProject, type KtxLocalProject } from '../../../src/context/project/project.js';
+
+const AUTHOR = 'Agent';
+const EMAIL = 'agent@example.com';
+
+const WIKI_PAGE = '---\nsummary: Revenue\nusage_mode: auto\n---\n\nPaid orders.\n';
+
+/**
+ * Regression for the "wiki silently unsearchable when the project dir is not the git root"
+ * bug: a ktx project initialized below an existing git working tree. ingest writes wiki
+ * pages through a session worktree and squash-merges into main, so the page must land
+ * inside the project dir (where reindex scans), not at the enclosing git root.
+ */
+describe('reindex with a ktx project nested inside an enclosing git repo', () => {
+  let tempDir: string;
+  let enclosing: string;
+  let projectDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'ktx-nested-git-root-'));
+    enclosing = join(tempDir, 'enclosing');
+    await mkdir(enclosing, { recursive: true });
+    execFileSync('git', ['init', '-q'], { cwd: enclosing });
+    projectDir = join(enclosing, 'analytics');
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('indexes a wiki page written through a session worktree and squash-merged into main', async () => {
+    const project: KtxLocalProject = await initKtxProject({
+      projectDir,
+      authorName: AUTHOR,
+      authorEmail: EMAIL,
+    });
+
+    // Mirror the ingest write path: create a session worktree, write the page on its
+    // branch through the worktree-scoped file store, then squash-merge into main.
+    const mainHead = await project.git.revParseHead();
+    const workdir = join(projectDir, '.ktx/worktrees/session-test');
+    const branch = 'session/test';
+    await project.git.addWorktree(workdir, branch, mainHead);
+    const worktreeStore = project.fileStore.forWorktree(workdir);
+    await worktreeStore.writeFile('wiki/global/revenue.md', WIKI_PAGE, AUTHOR, EMAIL, 'Add revenue page');
+    const merge = await project.git.squashMergeIntoMain(branch, AUTHOR, EMAIL, 'Merge session');
+    expect(merge.ok).toBe(true);
+    await project.git.removeWorktree(workdir);
+    await project.git.deleteBranch(branch, true);
+
+    // The page must land inside the project dir, not the enclosing git root.
+    await expect(stat(join(projectDir, 'wiki/global/revenue.md'))).resolves.toBeDefined();
+    await expect(stat(join(enclosing, 'wiki/global/revenue.md'))).rejects.toMatchObject({ code: 'ENOENT' });
+
+    // ...and reindex must discover and index it.
+    const summary = await reindexLocalIndexes(project, { force: false, embeddingService: null });
+    const global = summary.scopes.find((scope) => scope.label === 'global');
+    expect(global).toMatchObject({ scanned: 1, updated: 1 });
+  });
+});

--- a/packages/cli/test/context/project/project.test.ts
+++ b/packages/cli/test/context/project/project.test.ts
@@ -1,4 +1,5 @@
-import { mkdtemp, readFile, rm, stat } from 'node:fs/promises';
+import { execFileSync } from 'node:child_process';
+import { mkdir, mkdtemp, readFile, realpath, rm, stat } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -58,6 +59,30 @@ describe('KTX local project runtime', () => {
     await expect(loaded.fileStore.readFile('wiki/global/revenue.md')).resolves.toMatchObject({
       content: '# Revenue\n',
     });
+  });
+
+  it('initializes a dedicated git repo at the project dir even when nested inside an enclosing repo', async () => {
+    // A ktx project dir living below an existing git working tree (e.g. an analytics
+    // subfolder of an app repo). ktx must own its own repo rooted at the project dir,
+    // not silently adopt the enclosing repo — otherwise worktree writes resolve against
+    // the enclosing root and land outside the project dir.
+    const enclosing = join(tempDir, 'enclosing');
+    await mkdir(enclosing, { recursive: true });
+    execFileSync('git', ['init', '-q'], { cwd: enclosing });
+
+    const projectDir = join(enclosing, 'analytics');
+    await initKtxProject({ projectDir, authorName: 'Agent', authorEmail: 'agent@example.com' });
+
+    await expect(stat(join(projectDir, '.git'))).resolves.toBeDefined();
+    const toplevel = execFileSync('git', ['rev-parse', '--show-toplevel'], {
+      cwd: projectDir,
+      encoding: 'utf-8',
+    }).trim();
+    expect(await realpath(toplevel)).toBe(await realpath(projectDir));
+
+    // ktx must not write its scaffold commits into the user's enclosing repo.
+    const enclosingTracked = execFileSync('git', ['ls-files'], { cwd: enclosing, encoding: 'utf-8' });
+    expect(enclosingTracked).not.toContain('ktx.yaml');
   });
 
   it('rejects reinitializing an existing project unless force is set', async () => {


### PR DESCRIPTION
## Summary
- Initialize a dedicated git repository at the ktx project directory when it is nested under an enclosing repo.
- Add regression tests covering scaffold commits, session worktree squash merges, and reindex discovery for nested projects.

## Validation
- `pnpm --filter @kaelio/ktx exec vitest run test/context/project/project.test.ts test/context/index-sync/reindex.nested-git-root.test.ts`
- `pnpm --filter @kaelio/ktx run type-check`