### PR TITLE
test(ingest): supply explicit no-input schema scope in skip-llm setup test

### DIFF
--- a/packages/cli/test/ingest.test.ts
+++ b/packages/cli/test/ingest.test.ts
@@ -271,7 +271,7 @@ describe('runKtxIngest', () => {
           databaseDrivers: ['postgres'],
           databaseConnectionId: 'warehouse',
           databaseUrl: 'env:WAREHOUSE_URL',
-          databaseSchemas: [],
+          databaseSchemas: ['public'],
           enableQueryHistory: true,
           skipDatabases: false,
           skipSources: true,


### PR DESCRIPTION
Fixes the red `Slow TypeScript tests` job: `test/ingest.test.ts` "prints provider setup guidance when a skip-llm setup project runs ingest" failed because `runKtxSetup` returned `1` instead of `0`. PR #286 ("require explicit no-input database scope") changed setup so a `--no-input` postgres run must supply schemas explicitly rather than auto-scanning, and it updated `setup-databases.test.ts` but missed this `runKtxSetup` call, which still passed `databaseSchemas: []`. This passes `databaseSchemas: ['public']` to satisfy the new contract, matching #286's own test updates. The failure had already merged to `main` via #283, so `main`'s CI was broken until this fix. Verified: the previously-failing test and the full `ingest.test.ts` (36 tests) pass, and `type-check` is clean.