### PR TITLE
fix(deps): bump hono override to 4.12.21 to resolve dependabot alerts

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ overrides:
   brace-expansion@>=5.0.0 <5.0.6: 5.0.6
   fast-uri: 3.1.2
   fast-xml-builder: 1.1.7
-  hono: 4.12.18
+  hono: 4.12.21
   ip-address: 10.1.1
   postcss: 8.5.10
   ws: 8.20.1
@@ -979,7 +979,7 @@ packages:
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: 4.12.18
+      hono: 4.12.21
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -3763,8 +3763,8 @@ packages:
     resolution: {integrity: sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==}
     engines: {node: '>=0.10.0'}
 
-  hono@4.12.18:
-    resolution: {integrity: sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==}
+  hono@4.12.21:
+    resolution: {integrity: sha512-uV63apnb0kyPtAUwoWgaGh9HyIFcv8lgmzPZSiTBQAFOFGIzka5EZ1dZocmGnn0XdX0+XTqJ6Tqv7selMuGLRQ==}
     engines: {node: '>=16.9.0'}
 
   hook-std@4.0.0:
@@ -6004,8 +6004,8 @@ snapshots:
   '@ai-sdk/devtools@0.0.18':
     dependencies:
       '@ai-sdk/provider': 3.0.10
-      '@hono/node-server': 1.19.14(hono@4.12.18)
-      hono: 4.12.18
+      '@hono/node-server': 1.19.14(hono@4.12.21)
+      hono: 4.12.21
 
   '@ai-sdk/gateway@3.0.118(zod@4.4.3)':
     dependencies:
@@ -6918,9 +6918,9 @@ snapshots:
 
   '@google-cloud/promisify@5.0.0': {}
 
-  '@hono/node-server@1.19.14(hono@4.12.18)':
+  '@hono/node-server@1.19.14(hono@4.12.21)':
     dependencies:
-      hono: 4.12.18
+      hono: 4.12.21
 
   '@img/colour@1.1.0':
     optional: true
@@ -7092,7 +7092,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.18)
+      '@hono/node-server': 1.19.14(hono@4.12.21)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -7102,7 +7102,7 @@ snapshots:
       eventsource-parser: 3.0.8
       express: 5.2.1
       express-rate-limit: 8.5.2(express@5.2.1)
-      hono: 4.12.18
+      hono: 4.12.21
       jose: 6.2.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -9711,7 +9711,7 @@ snapshots:
     dependencies:
       parse-passwd: 1.0.0
 
-  hono@4.12.18: {}
+  hono@4.12.21: {}
 
   hook-std@4.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,7 +7,7 @@ overrides:
   "brace-expansion@>=5.0.0 <5.0.6": 5.0.6
   fast-uri: 3.1.2
   fast-xml-builder: 1.1.7
-  hono: 4.12.18
+  hono: 4.12.21
   ip-address: 10.1.1
   postcss: 8.5.10
   ws: 8.20.1


### PR DESCRIPTION
Bumps the workspace `hono` override from 4.12.18 to 4.12.21 and re-resolves the lockfile, fixing Dependabot alerts #22–#25 (GHSA-f577-qrjj-4474, GHSA-2gcr-mfcq-wcc3, GHSA-xrhx-7g5j-rcj5, GHSA-3hrh-pfw6-9m5x). `hono` is only a transitive dependency via `@modelcontextprotocol/sdk` and `@ai-sdk/devtools`, pinned by the override added in #179. All dependent ranges accept `^4.x`, and 4.12.21 (published 2026-05-19) passes the 7-day `minimumReleaseAge` gate. Verified with `pnpm run build`, the full `@kaelio/ktx` test suite (2849 passed), and the smoke suite.