### PR TITLE
fix(cli): stop framing Claude Code session limits as auth failures (KLO-734)

### DIFF
--- a/packages/cli/src/context/llm/claude-code-runtime.ts
+++ b/packages/cli/src/context/llm/claude-code-runtime.ts
@@ -151,7 +151,26 @@ function expectedMcpServerNames(tools: KtxRuntimeToolSet | undefined): Set<strin
   return tools && Object.keys(tools).length > 0 ? new Set([KTX_MCP_SERVER_NAME]) : new Set();
 }
 
-const CLAUDE_RATE_LIMIT_ERROR_MARKERS = /\b429\b|rate limit|too many requests|quota exceeded|overloaded|max_retries/i;
+// "session limit" is the Claude Code subscription cap ("You've hit your session
+// limit · resets …"); the rest are transient 429-style throttling. All mean
+// Claude Code authenticated successfully, so they must not be read as auth
+// failures by the governor classifier or the auth probe.
+const CLAUDE_RATE_LIMIT_ERROR_MARKERS =
+  /\b429\b|rate limit|session limit|usage limit|too many requests|quota exceeded|overloaded|max_retries/i;
+
+// The subscription cap is its own case: re-authenticating and retrying both fail
+// until reset, so it gets a distinct message from transient rate limiting.
+const CLAUDE_SESSION_LIMIT_MARKERS = /session limit|usage limit/i;
+
+function describeClaudeProbeFailure(message: string): string {
+  if (CLAUDE_SESSION_LIMIT_MARKERS.test(message)) {
+    return `Claude Code session limit reached. Wait for the reset shown, then rerun setup or the command. Details: ${message}`;
+  }
+  if (CLAUDE_RATE_LIMIT_ERROR_MARKERS.test(message)) {
+    return `Claude Code is rate limited. Retry shortly, then rerun setup or the command. Details: ${message}`;
+  }
+  return `Claude Code authentication is not usable. Authenticate Claude Code locally with the Claude Code CLI, then rerun setup or the command. ${message}`;
+}
 
 function normalizeClaudeResetAtMs(value: unknown): number | undefined {
   if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
@@ -497,7 +516,7 @@ export async function runClaudeCodeAuthProbe(input: {
     const message = error instanceof Error ? error.message : String(error);
     return {
       ok: false,
-      message: `Claude Code authentication is not usable. Authenticate Claude Code locally with the Claude Code CLI, then rerun setup or the command. ${message}`,
+      message: describeClaudeProbeFailure(message),
     };
   }
 }

--- a/packages/cli/test/context/llm/claude-code-runtime.test.ts
+++ b/packages/cli/test/context/llm/claude-code-runtime.test.ts
@@ -738,4 +738,70 @@ describe('ClaudeCodeKtxLlmRuntime', () => {
       message: 'Unsupported Claude Code model "gpt-5". Use sonnet, opus, haiku, or a claude-* model id.',
     });
   });
+
+  it('reports a Claude Code session limit as a session limit, not an auth or ktx failure', async () => {
+    const query = vi.fn((_input: any) =>
+      stream([
+        initMessage(),
+        resultMessage({
+          subtype: 'error_during_execution',
+          is_error: true,
+          errors: ["You've hit your session limit · resets 10:50pm (Asia/Saigon)"],
+        }),
+      ]),
+    );
+
+    const result = await runClaudeCodeAuthProbe({ projectDir: '/tmp/project', model: 'sonnet', query, env: {} });
+    const message = (result as { message: string }).message;
+
+    expect(result.ok).toBe(false);
+    // Auth worked; the subscription is capped. Must not tell the user to re-authenticate.
+    expect(message).not.toContain('authentication is not usable');
+    // Frame it as Claude Code's session limit, tell them to wait, and preserve the reset text.
+    expect(message).toContain('Claude Code session limit reached');
+    expect(message).toContain('Wait for the reset shown');
+    expect(message).toContain('resets 10:50pm (Asia/Saigon)');
+  });
+
+  it('reports a Claude Code rate limit as a rate limit, not an auth failure', async () => {
+    const query = vi.fn((_input: any) =>
+      stream([
+        initMessage(),
+        resultMessage({
+          subtype: 'error_during_execution',
+          is_error: true,
+          errors: ['API Error: 429 Too Many Requests'],
+        }),
+      ]),
+    );
+
+    const result = await runClaudeCodeAuthProbe({ projectDir: '/tmp/project', model: 'sonnet', query, env: {} });
+    const message = (result as { message: string }).message;
+
+    expect(result.ok).toBe(false);
+    expect(message).not.toContain('authentication is not usable');
+    expect(message).toContain('Claude Code is rate limited');
+    expect(message).toContain('429 Too Many Requests');
+  });
+
+  it('still reports a genuine auth failure as an auth failure', async () => {
+    const query = vi.fn((_input: any) =>
+      stream([
+        initMessage(),
+        resultMessage({
+          subtype: 'error_during_execution',
+          is_error: true,
+          errors: ['Invalid API key · Please run `claude login`'],
+        }),
+      ]),
+    );
+
+    const result = await runClaudeCodeAuthProbe({ projectDir: '/tmp/project', model: 'sonnet', query, env: {} });
+    const message = (result as { message: string }).message;
+
+    expect(result.ok).toBe(false);
+    expect(message).toContain('authentication is not usable');
+    expect(message).not.toContain('session limit reached');
+    expect(message).not.toContain('rate limited');
+  });
 });


### PR DESCRIPTION
## Problem

The Claude Code auth probe (`runClaudeCodeAuthProbe`) wrapped **every** probe error as `Claude Code authentication is not usable…`. When the subscription hits its session limit, the user saw:

```
Claude Code authentication is not usable. Authenticate Claude Code locally with the Claude Code CLI, then rerun setup or the command. … You've hit your session limit · resets 10:50pm (Asia/Saigon)
```

That advice is wrong: auth already **succeeded**. Re-authenticating cannot help — only the reset clears the cap. (KLO-734)

## Fix

Discriminate probe failures with a new `describeClaudeProbeFailure`, mirroring the existing `describeCodexProbeFailure` pattern in the sibling runtime:

- **Session limit** (`session limit` / `usage limit`) → "Claude Code session limit reached. Wait for the reset shown…", preserving the upstream text so the reset time survives.
- **Rate limit** (429 / overloaded / etc.) → "Claude Code is rate limited. Retry shortly…".
- **Otherwise** → the original auth message, unchanged.

Also extended the shared `CLAUDE_RATE_LIMIT_ERROR_MARKERS` with the session/usage-limit phrasing so the governor's classifier (`isClaudeRateLimitResult`) stops treating a cap as a generic error — one source of truth, both the probe and the streaming path benefit.

### Why string markers, not a typed field

The Claude Code / Agent SDK docs were checked: the session-limit phrasing is a **client UI string**, not a documented API `error.type`. In the probe path (`maxTurns: 1`, no governor) it arrives as free text in the result's `errors[]`, so marker matching on that text is the correct channel. The marker is anchored on the stable `session limit` phrase and deliberately **not** broadened to loose words like "limit"/"resets", which would risk swallowing genuine auth errors.

## Tests

Added three cases to `claude-code-runtime.test.ts`:
- session limit → reported as a session limit, reset text preserved, not an auth failure
- rate limit (429) → reported as a rate limit, not an auth failure
- genuine auth failure → still reported as an auth failure (guards the marker from over-matching)

## Verification

- `vitest` `claude-code-runtime.test.ts`: 22/22 pass
- `pnpm --filter @kaelio/ktx run type-check`: clean
- `pnpm run dead-code` (Biome + Knip default + production): clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)