### PR TITLE
test(cli): persist warehouse connection in sl query tests

### DIFF
--- a/packages/cli/test/sl.test.ts
+++ b/packages/cli/test/sl.test.ts
@@ -618,6 +618,15 @@ joins: []
     vi.stubEnv('CI', '');
     const projectDir = join(tempDir, 'project');
     await seedSlSource({ projectDir });
+    const config = parseKtxProjectConfig(await readFile(join(projectDir, 'ktx.yaml'), 'utf-8'));
+    await writeFile(
+      join(projectDir, 'ktx.yaml'),
+      serializeKtxProjectConfig({
+        ...config,
+        connections: { ...config.connections, warehouse: { driver: 'postgres' } },
+      }),
+      'utf-8',
+    );
     const io = makeIo({ isTTY: true });
     const createSemanticLayerCompute = vi.fn(() => ({
       query: vi.fn(async () => ({
@@ -654,6 +663,7 @@ joins: []
     const projectDir = join(tempDir, 'project');
     const project = await initKtxProject({ projectDir });
     project.config.connections.warehouse = { driver: 'postgres' };
+    await writeFile(join(projectDir, 'ktx.yaml'), serializeKtxProjectConfig(project.config), 'utf-8');
     await project.fileStore.writeFile(
       'semantic-layer/warehouse/orders.yaml',
       `name: orders
@@ -721,6 +731,7 @@ joins: []
     const projectDir = join(tempDir, 'project');
     const project = await initKtxProject({ projectDir });
     project.config.connections.warehouse = { driver: 'postgres' };
+    await writeFile(join(projectDir, 'ktx.yaml'), serializeKtxProjectConfig(project.config), 'utf-8');
     await project.fileStore.writeFile(
       'semantic-layer/warehouse/orders.yaml',
       `name: orders


### PR DESCRIPTION
The **Slow TypeScript tests** job on `main` was failing: three `runKtxSl` tests in `test/sl.test.ts` returned exit code `1` instead of `0`. #301 (`8a506015`) correctly strengthened `resolveLocalConnectionId` to reject a connection absent from `ktx.yaml`, but those tests configured the `warehouse` connection only in memory (or not at all) while `runKtxSl` reloads the project from disk via `loadKtxProject`, so the connection was never seen. #301 updated the other affected test files but missed this one because it lives in the slow bucket that doesn't gate PRs. This persists the connection to `ktx.yaml` so it survives the reload and the tests exercise the real on-disk load path; `test/sl.test.ts` is now 24/24 green and the package type-check is clean.