### PR TITLE
fix(sl): parse user filter expressions as predicates, not projections

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -263,22 +263,31 @@ and route ingest, setup, memory, indexing, and docs through it. Do not add an
 `auto_commit`-style switch unless the user explicitly asks for staged-only runs
 and accepts the extra runtime path.
 
-## Code Comments
+## Code Comments and Docstrings
 
-Code must be self-explanatory. A comment exists only to state a constraint the
-code cannot show; everything else belongs in the PR description or nowhere.
+Code must be self-explanatory. Clear names, types, and signatures do the
+documenting; a comment or docstring exists only to state what the code cannot
+show. Everything else belongs in the PR description or nowhere.
 
 - **MUST**: Keep each comment to 1-3 lines stating only what the code cannot
   show: a cross-file invariant ("error-severity issues never reach here — the
   doctor exits on them first"), a required ordering ("ktx.yaml is written
   before git init, so a crash cannot leave a bare `.git`"), or a library quirk
   ("zod reports unknown record keys as `invalid_key`").
+- **MUST**: Hold docstrings (Python `"""..."""`, JSDoc/TSDoc) to the same bar.
+  A docstring states a function's purpose or contract in 1-3 lines; when a real
+  quirk or invariant motivates the code, note it once and briefly. Let
+  self-explanatory code carry the rest — a well-named, well-typed function
+  often needs no docstring at all.
 - **MUST**: State each invariant once, at the public entry point. Do not repeat
-  the same guarantee across a helper, its wrapper, and the call site.
-- **MUST NOT**: Write prose comment blocks — design rationale, alternatives
-  considered, change narration ("is now written before…"), caller enumerations
-  ("shared by X, Y, and Z"), or restatements of what the code already shows.
-  That is the author addressing the reviewer, and it rots once merged.
+  the same guarantee across a module docstring, a helper, its wrapper, and the
+  call site.
+- **MUST NOT**: Write multi-paragraph docstrings or prose comment blocks —
+  design rationale, alternatives considered, change narration ("is now written
+  before…"), caller enumerations ("shared by X, Y, and Z"), worked examples
+  that restate the code, or the same explanation repeated in a module docstring
+  and the function it describes. That is the author addressing the reviewer; it
+  belongs in the PR description and rots once merged.
 - **MAY**: Open a regression test with a 1-3 line comment stating the scenario
   it guards when the test name cannot carry it. Omit design history and
   references to removed designs.

--- a/python/ktx-sl/semantic_layer/generator.py
+++ b/python/ktx-sl/semantic_layer/generator.py
@@ -1297,10 +1297,8 @@ class SqlGenerator:
             return expr
 
         try:
-            # Parse as a predicate, not a projection: T-SQL reads a top-level
-            # `col = 'value'` projection (a WHERE filter) as `alias = expression`,
-            # hiding the column so expansion silently no-ops. Identical to a
-            # projection parse for plain exprs.
+            # Parse as a predicate so T-SQL equality filters are not read as
+            # `alias = expression` projections that hide computed columns.
             tree = sqlglot.parse_one(
                 f"SELECT * WHERE {quote_reserved_identifiers(expr)}",
                 read=self.dialect,

--- a/python/ktx-sl/semantic_layer/generator.py
+++ b/python/ktx-sl/semantic_layer/generator.py
@@ -673,9 +673,14 @@ class SqlGenerator:
             if isinstance(select_expr, exp.Alias):
                 select_expr = select_expr.this
 
-            filter_cond = sqlglot.parse_one(
-                f"SELECT {filter_sql}", read=self.dialect
-            ).expressions[0]
+            # Parse the filter as a predicate, not a projection: in T-SQL a
+            # top-level `col = 'value'` projection is `alias = expression`
+            # syntax, which would inject `'value' AS col` into the CASE WHEN.
+            filter_cond = (
+                sqlglot.parse_one(f"SELECT * WHERE {filter_sql}", read=self.dialect)
+                .find(exp.Where)
+                .this
+            )
 
             def _make_case(inner_node):
                 return exp.Case(
@@ -1292,9 +1297,15 @@ class SqlGenerator:
             return expr
 
         try:
+            # Parse as a predicate, not a projection: T-SQL reads a top-level
+            # `col = 'value'` projection (a WHERE filter) as `alias = expression`,
+            # hiding the column so expansion silently no-ops. Identical to a
+            # projection parse for plain exprs.
             tree = sqlglot.parse_one(
-                f"SELECT {quote_reserved_identifiers(expr)}", read=self.dialect
+                f"SELECT * WHERE {quote_reserved_identifiers(expr)}",
+                read=self.dialect,
             )
+            condition = tree.find(exp.Where).this
 
             changed = False
 
@@ -1309,9 +1320,9 @@ class SqlGenerator:
                         ).expressions[0]
                 return node
 
-            transformed = tree.transform(_replace)
+            transformed = condition.transform(_replace)
             if changed:
-                return transformed.expressions[0].sql(dialect=self.dialect)
+                return transformed.sql(dialect=self.dialect)
         except Exception:
             logger.debug("AST-based computed column expansion failed for: %s", expr)
 

--- a/python/ktx-sl/semantic_layer/generator.py
+++ b/python/ktx-sl/semantic_layer/generator.py
@@ -15,7 +15,11 @@ from semantic_layer.models import (
     ResolvedPlan,
     SourceDefinition,
 )
-from semantic_layer.parser import ExpressionParser, quote_reserved_identifiers
+from semantic_layer.parser import (
+    ExpressionParser,
+    parse_predicate,
+    quote_reserved_identifiers,
+)
 
 # DIALECT CONVENTION:
 #   User-authored SQL fragments (measure `expr`, segment `expr`, filter,
@@ -673,14 +677,7 @@ class SqlGenerator:
             if isinstance(select_expr, exp.Alias):
                 select_expr = select_expr.this
 
-            # Parse the filter as a predicate, not a projection: in T-SQL a
-            # top-level `col = 'value'` projection is `alias = expression`
-            # syntax, which would inject `'value' AS col` into the CASE WHEN.
-            filter_cond = (
-                sqlglot.parse_one(f"SELECT * WHERE {filter_sql}", read=self.dialect)
-                .find(exp.Where)
-                .this
-            )
+            filter_cond = parse_predicate(filter_sql, self.dialect)
 
             def _make_case(inner_node):
                 return exp.Case(
@@ -1078,10 +1075,7 @@ class SqlGenerator:
 
         # AST-based rewriting for robustness
         try:
-            tree = sqlglot.parse_one(
-                f"SELECT {quote_reserved_identifiers(filter_expr)}",
-                read=self.dialect,
-            )
+            condition = parse_predicate(filter_expr, self.dialect)
 
             def _rewrite(node):
                 if isinstance(node, (exp.AggFunc, exp.Anonymous)):
@@ -1104,8 +1098,8 @@ class SqlGenerator:
                         ).expressions[0]
                 return node
 
-            transformed = tree.transform(_rewrite)
-            return transformed.expressions[0].sql(dialect=self.dialect)
+            transformed = condition.transform(_rewrite)
+            return transformed.sql(dialect=self.dialect)
         except Exception:
             logger.debug(
                 "AST-based HAVING rewrite failed for locality filter, falling back to regex: %s",
@@ -1297,13 +1291,7 @@ class SqlGenerator:
             return expr
 
         try:
-            # Parse as a predicate so T-SQL equality filters are not read as
-            # `alias = expression` projections that hide computed columns.
-            tree = sqlglot.parse_one(
-                f"SELECT * WHERE {quote_reserved_identifiers(expr)}",
-                read=self.dialect,
-            )
-            condition = tree.find(exp.Where).this
+            condition = parse_predicate(expr, self.dialect)
 
             changed = False
 
@@ -1366,13 +1354,7 @@ class SqlGenerator:
 
         # Use AST to find and replace column references matching measure names
         try:
-            tree = sqlglot.parse_one(
-                f"SELECT * WHERE {quote_reserved_identifiers(f)}",
-                dialect=self.dialect,
-            )
-            where = tree.find(exp.Where)
-            if not where:
-                return f
+            condition = parse_predicate(f, self.dialect)
 
             changed = False
 
@@ -1397,7 +1379,7 @@ class SqlGenerator:
                         ).expressions[0]
                 return node
 
-            new_where = where.this.transform(_replace)
+            new_where = condition.transform(_replace)
             if changed:
                 return new_where.sql(dialect=self.dialect)
         except Exception:

--- a/python/ktx-sl/semantic_layer/parser.py
+++ b/python/ktx-sl/semantic_layer/parser.py
@@ -222,8 +222,16 @@ class ExpressionParser:
         return quote_reserved_identifiers(expr)
 
     def _parse_as_select(self, quoted_expr: str) -> exp.Expression:
-        """Parse expression wrapped in SELECT, using cache for repeated expressions."""
-        return _cached_parse_select(f"SELECT {quoted_expr}", self.dialect)
+        """Parse a user fragment for read-only AST walks, using the parse cache.
+
+        Wrapped in a WHERE clause rather than a bare projection: in T-SQL a
+        top-level `col = 'value'` projection is the `alias = expression`
+        aliasing syntax, so a filter parsed as `SELECT col = 'value'` becomes
+        `'value' AS col` and hides the comparison's column from the walk.
+        Wrapping as a predicate parses it as the comparison in every dialect;
+        for non-condition exprs the column set is identical either way.
+        """
+        return _cached_parse_select(f"SELECT * WHERE {quoted_expr}", self.dialect)
 
     def parse(
         self,

--- a/python/ktx-sl/semantic_layer/parser.py
+++ b/python/ktx-sl/semantic_layer/parser.py
@@ -222,14 +222,10 @@ class ExpressionParser:
         return quote_reserved_identifiers(expr)
 
     def _parse_as_select(self, quoted_expr: str) -> exp.Expression:
-        """Parse a user fragment for read-only AST walks, using the parse cache.
+        """Parse a user fragment as a predicate for read-only AST walks, via the cache.
 
-        Wrapped in a WHERE clause rather than a bare projection: in T-SQL a
-        top-level `col = 'value'` projection is the `alias = expression`
-        aliasing syntax, so a filter parsed as `SELECT col = 'value'` becomes
-        `'value' AS col` and hides the comparison's column from the walk.
-        Wrapping as a predicate parses it as the comparison in every dialect;
-        for non-condition exprs the column set is identical either way.
+        WHERE, not a bare projection: a top-level `col = 'value'` is T-SQL's
+        `alias = expression` aliasing form, which would hide the column.
         """
         return _cached_parse_select(f"SELECT * WHERE {quoted_expr}", self.dialect)
 

--- a/python/ktx-sl/semantic_layer/parser.py
+++ b/python/ktx-sl/semantic_layer/parser.py
@@ -196,6 +196,15 @@ def quote_reserved_identifiers(expr: str) -> str:
     return result
 
 
+def _predicate_select(expr: str) -> str:
+    """Wrap a user expression as `SELECT * WHERE …`, quoting reserved identifiers.
+
+    Predicate, not projection: T-SQL reads a top-level `col = 'value'` projection
+    as the `alias = expression` form and would compile the filter to `'value' AS col`.
+    """
+    return f"SELECT * WHERE {quote_reserved_identifiers(expr)}"
+
+
 @functools.lru_cache(maxsize=256)
 def _cached_parse_select(sql: str, dialect: str) -> exp.Expression:
     """Cache parsed SELECT wrapper trees keyed by (sql, dialect).
@@ -204,6 +213,14 @@ def _cached_parse_select(sql: str, dialect: str) -> exp.Expression:
     dialects don't share AST cache collisions.
     """
     return sqlglot.parse_one(sql, read=dialect)
+
+
+def parse_predicate(expr: str, dialect: str) -> exp.Expression:
+    """Parse a user filter into a fresh, mutable WHERE-condition node.
+
+    Uncached, so the result is safe to `.transform()`; raises on unparseable input.
+    """
+    return sqlglot.parse_one(_predicate_select(expr), read=dialect).find(exp.Where).this
 
 
 class ExpressionParser:
@@ -218,16 +235,9 @@ class ExpressionParser:
     def __init__(self, dialect: str = "postgres") -> None:
         self.dialect = dialect
 
-    def _quote_reserved_identifiers(self, expr: str) -> str:
-        return quote_reserved_identifiers(expr)
-
-    def _parse_as_select(self, quoted_expr: str) -> exp.Expression:
-        """Parse a user fragment as a predicate for read-only AST walks, via the cache.
-
-        WHERE, not a bare projection: a top-level `col = 'value'` is T-SQL's
-        `alias = expression` aliasing form, which would hide the column.
-        """
-        return _cached_parse_select(f"SELECT * WHERE {quoted_expr}", self.dialect)
+    def _parse_as_select(self, expr: str) -> exp.Expression:
+        """Parse a user fragment for read-only AST walks, via the parse cache."""
+        return _cached_parse_select(_predicate_select(expr), self.dialect)
 
     def parse(
         self,
@@ -240,8 +250,7 @@ class ExpressionParser:
         if not expr or not expr.strip():
             return result
 
-        quoted_expr = self._quote_reserved_identifiers(expr)
-        tree = self._parse_as_select(quoted_expr)
+        tree = self._parse_as_select(expr)
 
         # Extract source.column references
         for col in tree.find_all(exp.Column):
@@ -300,8 +309,7 @@ class ExpressionParser:
         """Quick extraction of source names from an expression."""
         if not expr or not expr.strip():
             return set()
-        quoted_expr = self._quote_reserved_identifiers(expr)
-        tree = self._parse_as_select(quoted_expr)
+        tree = self._parse_as_select(expr)
         return {
             _strip_quotes(col.table) for col in tree.find_all(exp.Column) if col.table
         }

--- a/python/ktx-sl/semantic_layer/planner.py
+++ b/python/ktx-sl/semantic_layer/planner.py
@@ -910,10 +910,8 @@ class QueryPlanner:
         for c in source.columns:
             col_to_source[c.name] = source_name
 
-        # Parse as a predicate, not a projection: T-SQL reads a top-level
-        # `col = 'value'` projection (a measure filter / segment) as
-        # `alias = expression`, mangling it into `'value' AS col`. Identical to
-        # a projection parse for plain exprs.
+        # Parse as a predicate so T-SQL equality filters are not read as
+        # `alias = expression` projections before column qualification.
         tree = sqlglot.parse_one(
             f"SELECT * WHERE {quote_reserved_identifiers(expr)}", read=self.dialect
         )

--- a/python/ktx-sl/semantic_layer/planner.py
+++ b/python/ktx-sl/semantic_layer/planner.py
@@ -910,9 +910,14 @@ class QueryPlanner:
         for c in source.columns:
             col_to_source[c.name] = source_name
 
+        # Parse as a predicate, not a projection: T-SQL reads a top-level
+        # `col = 'value'` projection (a measure filter / segment) as
+        # `alias = expression`, mangling it into `'value' AS col`. Identical to
+        # a projection parse for plain exprs.
         tree = sqlglot.parse_one(
-            f"SELECT {quote_reserved_identifiers(expr)}", read=self.dialect
+            f"SELECT * WHERE {quote_reserved_identifiers(expr)}", read=self.dialect
         )
+        condition = tree.find(exp.Where).this
 
         def _qualify_column(node):
             if (
@@ -926,8 +931,8 @@ class QueryPlanner:
                 )
             return node
 
-        transformed = tree.transform(_qualify_column)
-        return transformed.expressions[0].sql(dialect=self.dialect)
+        transformed = condition.transform(_qualify_column)
+        return transformed.sql(dialect=self.dialect)
 
     def _detect_fan_out(
         self,

--- a/python/ktx-sl/semantic_layer/planner.py
+++ b/python/ktx-sl/semantic_layer/planner.py
@@ -22,7 +22,11 @@ from semantic_layer.models import (
     SemanticQuery,
     SourceDefinition,
 )
-from semantic_layer.parser import ExpressionParser, quote_reserved_identifiers
+from semantic_layer.parser import (
+    ExpressionParser,
+    parse_predicate,
+    quote_reserved_identifiers,
+)
 
 # DIALECT CONVENTION:
 #   User-authored measure `expr`, `filter`, and computed-column fragments must
@@ -910,12 +914,7 @@ class QueryPlanner:
         for c in source.columns:
             col_to_source[c.name] = source_name
 
-        # Parse as a predicate so T-SQL equality filters are not read as
-        # `alias = expression` projections before column qualification.
-        tree = sqlglot.parse_one(
-            f"SELECT * WHERE {quote_reserved_identifiers(expr)}", read=self.dialect
-        )
-        condition = tree.find(exp.Where).this
+        condition = parse_predicate(expr, self.dialect)
 
         def _qualify_column(node):
             if (
@@ -1257,14 +1256,7 @@ class QueryPlanner:
     ) -> None:
         """Raise an error if an OR expression mixes WHERE and HAVING conditions."""
         try:
-            tree = sqlglot.parse_one(
-                f"SELECT * WHERE {quote_reserved_identifiers(clause)}",
-                dialect=self.dialect,
-            )
-            where = tree.find(exp.Where)
-            if not where:
-                return
-            inner = where.this
+            inner = parse_predicate(clause, self.dialect)
             # Only check if the top level contains OR
             or_parts: list[str] = []
 
@@ -1298,14 +1290,7 @@ class QueryPlanner:
     def _split_top_level_and(self, expr: str) -> list[str]:
         """Split a filter expression on top-level AND (not inside parentheses or strings)."""
         try:
-            tree = sqlglot.parse_one(
-                f"SELECT * WHERE {quote_reserved_identifiers(expr)}",
-                dialect=self.dialect,
-            )
-            where = tree.find(exp.Where)
-            if not where:
-                return [expr]
-            inner = where.this
+            inner = parse_predicate(expr, self.dialect)
             parts: list[str] = []
 
             def _collect_and(node):

--- a/python/ktx-sl/tests/test_tsql_filter_alias_regression.py
+++ b/python/ktx-sl/tests/test_tsql_filter_alias_regression.py
@@ -1,11 +1,7 @@
 """Regression tests for T-SQL `=` filters mis-parsed as column aliases.
 
-In T-SQL, `SELECT col = 'value'` is the `alias = expression` projection
-syntax, so a filter parsed in a projection context (`SELECT {filter}`) becomes
-`'value' AS col` instead of an equality comparison. User-authored filters and
-segments must therefore be parsed as predicates, not projections. These tests
-lock that behavior across dialects so the same source compiles correctly
-everywhere.
+A top-level `col = 'value'` is T-SQL's `alias = expression` projection form, so
+filters and segments must compile as predicates, not projections, on any dialect.
 """
 
 from __future__ import annotations
@@ -92,9 +88,6 @@ def test_where_equality_filter_compiles_as_comparison(dialect):
 
 @pytest.mark.parametrize("dialect", DIALECTS)
 def test_computed_column_expands_in_equality_where_filter(dialect):
-    """A top-level `=` WHERE filter on a computed column must still expand the
-    column's expression — the projection-context parse silently skipped it on
-    T-SQL."""
     engine = make_engine({"jobs": _jobs_source()}, dialect=dialect)
     sql = engine.query(
         {"measures": ["sum(jobs.amount)"], "filters": ["jobs.doubled = 10"]}
@@ -108,8 +101,7 @@ def test_computed_column_expands_in_equality_where_filter(dialect):
 
 
 def test_tsql_equality_and_in_filters_are_equivalent_shape():
-    """`= 'x'` and `IN ('x')` filters should both reach the warehouse as
-    predicates on T-SQL; `IN` was only ever a coincidental workaround."""
+    """On T-SQL, `= 'x'` and `IN ('x')` filters both compile to predicates."""
     eq_engine = make_engine({"jobs": _jobs_source()}, dialect="tsql")
     in_engine = make_engine(
         {

--- a/python/ktx-sl/tests/test_tsql_filter_alias_regression.py
+++ b/python/ktx-sl/tests/test_tsql_filter_alias_regression.py
@@ -39,6 +39,38 @@ def _jobs_source(**overrides):
     return base
 
 
+def _chasm_sources():
+    """Two facts fanning out from a shared hub — triggers aggregate locality, the
+    path that rewrites HAVING filters against measure references."""
+    fact = lambda name: {  # noqa: E731
+        "name": name,
+        "table": f"dbo.{name}",
+        "grain": ["id"],
+        "columns": [
+            {"name": "id", "type": "number"},
+            {"name": "hub_id", "type": "number"},
+            {"name": "val", "type": "number"},
+        ],
+        "joins": [
+            {"to": "hub", "on": "hub_id = hub.id", "relationship": "many_to_one"}
+        ],
+        "measures": [{"name": f"{name}_total", "expr": "sum(val)"}],
+    }
+    return {
+        "hub": {
+            "name": "hub",
+            "table": "dbo.hub",
+            "grain": ["id"],
+            "columns": [
+                {"name": "id", "type": "number"},
+                {"name": "segment", "type": "string"},
+            ],
+        },
+        "fact_a": fact("fact_a"),
+        "fact_b": fact("fact_b"),
+    }
+
+
 def _assert_valid(sql: str, dialect: str) -> None:
     parsed = sqlglot.parse(sql, read=dialect)
     assert parsed and all(stmt is not None for stmt in parsed), sql
@@ -98,6 +130,23 @@ def test_computed_column_expands_in_equality_where_filter(dialect):
     # expression, not the (non-existent) computed column name.
     assert "base" in sql
     assert "doubled" not in sql
+
+
+@pytest.mark.parametrize("dialect", DIALECTS)
+def test_locality_named_measure_equality_filter_compiles_as_comparison(dialect):
+    """Aggregate-locality HAVING filter on a named measure must compile to a
+    comparison, not the `0 AS measure` alias form T-SQL emits."""
+    engine = make_engine(_chasm_sources(), dialect=dialect)
+    sql = engine.query(
+        {
+            "measures": ["fact_a.fact_a_total", "fact_b.fact_b_total"],
+            "dimensions": ["hub.segment"],
+            "filters": ["fact_a.fact_a_total = 0"],
+        }
+    ).sql
+
+    _assert_valid(sql, dialect)
+    assert "0 AS fact_a_total" not in sql
 
 
 def test_tsql_equality_and_in_filters_are_equivalent_shape():

--- a/python/ktx-sl/tests/test_tsql_filter_alias_regression.py
+++ b/python/ktx-sl/tests/test_tsql_filter_alias_regression.py
@@ -1,0 +1,134 @@
+"""Regression tests for T-SQL `=` filters mis-parsed as column aliases.
+
+In T-SQL, `SELECT col = 'value'` is the `alias = expression` projection
+syntax, so a filter parsed in a projection context (`SELECT {filter}`) becomes
+`'value' AS col` instead of an equality comparison. User-authored filters and
+segments must therefore be parsed as predicates, not projections. These tests
+lock that behavior across dialects so the same source compiles correctly
+everywhere.
+"""
+
+from __future__ import annotations
+
+import pytest
+import sqlglot
+
+from .conftest import make_engine
+
+
+def _jobs_source(**overrides):
+    base = {
+        "name": "jobs",
+        "table": "dbo.jobs",
+        "grain": ["id"],
+        "columns": [
+            {"name": "id", "type": "number"},
+            {"name": "amount", "type": "number"},
+            {"name": "trade_name", "type": "string"},
+            {"name": "base", "type": "number"},
+            {"name": "doubled", "type": "number", "expr": "base * 2"},
+        ],
+        "segments": [
+            {"name": "is_roofing", "expr": "trade_name = 'Roofing'"},
+        ],
+        "measures": [
+            {
+                "name": "roofing_rev",
+                "expr": "sum(amount)",
+                "filter": "trade_name = 'Roofing'",
+            },
+        ],
+    }
+    base.update(overrides)
+    return base
+
+
+def _assert_valid(sql: str, dialect: str) -> None:
+    parsed = sqlglot.parse(sql, read=dialect)
+    assert parsed and all(stmt is not None for stmt in parsed), sql
+
+
+# Dialects whose grammar contains the `alias = expression` projection form
+# alongside ones that do not, to guard the cross-dialect contract.
+DIALECTS = ["tsql", "postgres", "snowflake", "bigquery"]
+
+
+@pytest.mark.parametrize("dialect", DIALECTS)
+def test_measure_equality_filter_compiles_as_comparison(dialect):
+    engine = make_engine({"jobs": _jobs_source()}, dialect=dialect)
+    sql = engine.query({"measures": ["jobs.roofing_rev"]}).sql
+
+    _assert_valid(sql, dialect)
+    assert "CASE WHEN" in sql.upper()
+    assert "'Roofing'" in sql
+    # The filter must remain an equality comparison, never an aliased literal.
+    assert "AS trade_name" not in sql
+    assert "'Roofing' AS" not in sql
+
+
+@pytest.mark.parametrize("dialect", DIALECTS)
+def test_segment_equality_filter_compiles_as_comparison(dialect):
+    engine = make_engine({"jobs": _jobs_source()}, dialect=dialect)
+    sql = engine.query(
+        {"measures": ["sum(jobs.amount)"], "segments": ["jobs.is_roofing"]}
+    ).sql
+
+    _assert_valid(sql, dialect)
+    assert "CASE WHEN" in sql.upper()
+    assert "'Roofing' AS" not in sql
+
+
+@pytest.mark.parametrize("dialect", DIALECTS)
+def test_where_equality_filter_compiles_as_comparison(dialect):
+    engine = make_engine({"jobs": _jobs_source()}, dialect=dialect)
+    sql = engine.query(
+        {"measures": ["sum(jobs.amount)"], "filters": ["jobs.trade_name = 'Roofing'"]}
+    ).sql
+
+    _assert_valid(sql, dialect)
+    assert "WHERE" in sql.upper()
+    assert "'Roofing' AS" not in sql
+
+
+@pytest.mark.parametrize("dialect", DIALECTS)
+def test_computed_column_expands_in_equality_where_filter(dialect):
+    """A top-level `=` WHERE filter on a computed column must still expand the
+    column's expression — the projection-context parse silently skipped it on
+    T-SQL."""
+    engine = make_engine({"jobs": _jobs_source()}, dialect=dialect)
+    sql = engine.query(
+        {"measures": ["sum(jobs.amount)"], "filters": ["jobs.doubled = 10"]}
+    ).sql
+
+    _assert_valid(sql, dialect)
+    # `doubled` is computed (base * 2); the filter must reference the underlying
+    # expression, not the (non-existent) computed column name.
+    assert "base" in sql
+    assert "doubled" not in sql
+
+
+def test_tsql_equality_and_in_filters_are_equivalent_shape():
+    """`= 'x'` and `IN ('x')` filters should both reach the warehouse as
+    predicates on T-SQL; `IN` was only ever a coincidental workaround."""
+    eq_engine = make_engine({"jobs": _jobs_source()}, dialect="tsql")
+    in_engine = make_engine(
+        {
+            "jobs": _jobs_source(
+                measures=[
+                    {
+                        "name": "roofing_rev",
+                        "expr": "sum(amount)",
+                        "filter": "trade_name IN ('Roofing')",
+                    }
+                ]
+            )
+        },
+        dialect="tsql",
+    )
+    eq_sql = eq_engine.query({"measures": ["jobs.roofing_rev"]}).sql
+    in_sql = in_engine.query({"measures": ["jobs.roofing_rev"]}).sql
+
+    _assert_valid(eq_sql, "tsql")
+    _assert_valid(in_sql, "tsql")
+    assert "jobs.trade_name = 'Roofing'" in eq_sql
+    assert "jobs.trade_name IN ('Roofing')" in in_sql


### PR DESCRIPTION
## Problem

User-authored filters and segments were parsed in a **projection context** (`SELECT {expr}`). On T-SQL, a top-level `col = 'value'` projection is the `alias = expression` aliasing syntax — so an equality filter parsed this way silently became `'value' AS col`:

- The equality comparison was dropped entirely.
- Computed-column expansion no-op'd, because the column name hid behind the alias.
- `IN ('x')` happened to work only because it isn't valid alias syntax — it was a coincidental workaround, not a real fix.

This produced wrong (or silently mangled) SQL whenever a T-SQL source used a `col = 'value'` filter or segment.

## Fix

Parse user fragments as **predicates** (`SELECT * WHERE {expr}`) and read back the `WHERE` condition at every parse site:

- `parser.py` — `ExpressionParser._parse_as_select` (the read-only parse cache)
- `generator.py` — measure-filter `CASE WHEN` generation and computed-column expansion
- `planner.py` — measure-filter / segment column qualification

For plain non-condition expressions the resulting column set is identical, so this is a no-op everywhere except the T-SQL alias case it fixes. Uses sqlglot AST throughout — no regex on SQL structure.

## Tests

Adds `test_tsql_filter_alias_regression.py` — cross-dialect coverage (`tsql`, `postgres`, `snowflake`, `bigquery`) that:

- Locks equality measure filters, segments, and WHERE filters to comparison shape (never an aliased literal).
- Confirms computed columns still expand inside a `=` WHERE filter.
- Confirms `= 'x'` and `IN ('x')` now reach the warehouse as equivalent predicates on T-SQL.

## Verification

- `uv run pytest python/ktx-sl/tests -q` → 642 passed, 10 skipped
- `uv run pre-commit run --files ...` → all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)