### PR TITLE
fix(memory): land verified question/SQL pairs as executable measures and segments

### DIFF
--- a/packages/cli/src/context/memory/capture-signals.ts
+++ b/packages/cli/src/context/memory/capture-signals.ts
@@ -16,8 +16,18 @@ export function detectCaptureSignals(input: MemoryAgentInput): CaptureSignals {
   const assistantMessage = input.assistantMessage?.trim() ?? '';
   const reasons: string[] = [];
 
+  // The user-message length gate is a research-path proxy for "the turn was substantive
+  // enough to promote the assistant's SQL." External ingest carries a fixed boilerplate
+  // user message and keeps the real content in the assistant message, so the proxy never
+  // holds there - treat the deliberate submission itself as the substantive signal.
+  const deliberateSubmission = input.sourceType === 'external_ingest';
+
   let sl = false;
-  if (assistantMessage && SQL_AGGREGATE_PATTERN.test(assistantMessage) && userMessage.length >= 100) {
+  if (
+    assistantMessage &&
+    SQL_AGGREGATE_PATTERN.test(assistantMessage) &&
+    (deliberateSubmission || userMessage.length >= 100)
+  ) {
     sl = true;
     reasons.push('sql aggregate in assistant message');
   }

--- a/packages/cli/src/context/memory/memory-agent.service.ts
+++ b/packages/cli/src/context/memory/memory-agent.service.ts
@@ -615,14 +615,18 @@ export class MemoryAgentService {
         : sources
             .map((s) => {
               const measureCount = s.measures.length;
+              const segmentCount = s.segments?.length ?? 0;
               const joinCount = s.joins?.length ?? 0;
-              const header = `${s.name} [measures=${measureCount}, joins=${joinCount}]`;
-              if (measureCount === 0 && joinCount === 0) {
+              const header = `${s.name} [measures=${measureCount}, segments=${segmentCount}, joins=${joinCount}]`;
+              if (measureCount === 0 && segmentCount === 0 && joinCount === 0) {
                 return `${header} — candidate for enrichment`;
               }
               const parts: string[] = [header];
               if (measureCount > 0) {
                 parts.push(`  measures: ${s.measures.map((m) => `${s.name}.${m.name}`).join(', ')}`);
+              }
+              if (segmentCount > 0) {
+                parts.push(`  segments: ${(s.segments ?? []).map((seg) => seg.name).join(', ')}`);
               }
               if (joinCount > 0) {
                 parts.push(`  joins: ${(s.joins ?? []).map((j) => `→ ${j.to} (${j.relationship})`).join(', ')}`);

--- a/packages/cli/src/prompts/memory_agent_external_ingest.md
+++ b/packages/cli/src/prompts/memory_agent_external_ingest.md
@@ -8,9 +8,17 @@ Assertive. Unlike a chat turn, this content was deliberately submitted. Default 
 A single artifact typically produces multiple actions: one SL source per table/view, additional measures or joins per metric, and one wiki page per alias or convention.
 </stance>
 
+<verified_pairs>
+When the artifact contains verified question->SQL pairs, analyst-approved metrics, or any computation the submitter has already validated, the SQL is the source of truth - encode it, do not just describe it.
+
+- Each verified computation becomes a measure or segment on the source it queries: an aggregation is a measure, a reusable boolean predicate is a segment. Follow `sl_capture` for the measure/segment/overlay shape.
+- When a source already exists - including one the scan guessed from column names - revise it in place with `sl_edit_source` or an overlay so its executable definition follows the verified logic. The verified material is authoritative: where it conflicts with an existing definition, change the definition to match it rather than only noting the discrepancy in a wiki page.
+- Use the wiki for the business meaning a measure or segment cannot carry (what a status code means, why a filter applies, lineage). The computation itself lives in the SL.
+</verified_pairs>
+
 <workflow>
 1. Review the wiki and SL indexes in the prompt. Prefer updating existing entries over creating duplicates.
-2. Load the `sl` skill for SL-writes and `wiki_capture` for wiki-writes. Both skills describe schema, decision rules, and editing patterns - follow them.
+2. Load `sl_capture` (it pulls in `sl`) for SL-writes and `wiki_capture` for wiki-writes. Both skills describe schema, decision rules, and editing patterns - follow them.
 3. For each distinct element in the artifact (table/view, measure, dimension group, derived column, computed filter, business rule, alias): decide whether it belongs in the SL, in the wiki, or both.
 4. Write SL sources first (so they have stable names), then wiki pages that reference them via `sl_refs`.
 5. When the artifact mixes data definitions with business rules, capture BOTH - one in each store, linked.
@@ -22,7 +30,7 @@ All wiki writes go to the GLOBAL scope - they will be visible to every user of t
 </scope>
 
 <do_not>
-- Do not fabricate measures, joins, or rules that aren't in the artifact.
+- Do not fabricate measures, joins, or rules the artifact does not support. Encoding a computation the artifact demonstrates - a verified query, a formula, a stated rule - as a measure or segment is derivation from that evidence, not fabrication; a query implies a measure even when it does not declare one.
 - Do not invent column names. If a type is unclear, omit it rather than guess.
 - Do not mirror presentation hints (LookML `link:`, `map_layer_name:`, HTML formatting) into SL - those belong in wiki if anywhere.
 </do_not>

--- a/packages/cli/test/context/memory/memory-agent.service.test.ts
+++ b/packages/cli/test/context/memory/memory-agent.service.test.ts
@@ -31,6 +31,31 @@ describe('MemoryAgentService.detectCaptureSignals', () => {
     expect(result.sl).toBe(false);
   });
 
+  it('fires sl on assistant SQL for external_ingest despite a short boilerplate user message', () => {
+    // `ktx ingest --file` keeps the content in assistantMessage and uses a fixed boilerplate
+    // user message, so the substantive-turn gate must come from the deliberate submission itself.
+    const result = detectCaptureSignals({
+      userId: 'u',
+      chatId: 'c',
+      userMessage: 'Ingest external text artifact "verified_pairs.md" into ktx memory.',
+      assistantMessage: 'Q: total claims completed?\nSQL: SELECT COUNT(DISTINCT Claim_No_Date) FROM dimJob_Details',
+      sourceType: 'external_ingest',
+    });
+    expect(result.sl).toBe(true);
+    expect(result.reasons).toContain('sql aggregate in assistant message');
+  });
+
+  it('keeps the substantive-turn gate for non-ingest source types with a short user message', () => {
+    const result = detectCaptureSignals({
+      userId: 'u',
+      chatId: 'c',
+      userMessage: 'Ingest external text artifact "verified_pairs.md" into ktx memory.',
+      assistantMessage: 'SELECT COUNT(DISTINCT Claim_No_Date) FROM dimJob_Details',
+      sourceType: 'research',
+    });
+    expect(result.sl).toBe(false);
+  });
+
   it('fires sl on definition keywords in user message regardless of length', () => {
     const result = detectCaptureSignals({
       userId: 'u',


### PR DESCRIPTION
## Problem

Verified question/SQL pairs ingested through `ktx ingest --file` were being captured as wiki prose instead of executable measures/segments, so the semantic layer stayed whatever the warehouse scan guessed from column names. Even an explicit "define measures and segments" instruction produced zero SL writes on a corpus full of verified SQL.

## Root cause

Three independent issues on the `--file` memory-agent path:

1. **Signal gate.** `detectCaptureSignals` only fires the SL signal from SQL when `userMessage.length >= 100`. That gate is a reasonable proxy on the chat/research path, but `ktx ingest --file` sets `userMessage` to a fixed boilerplate string and carries the artifact in `assistantMessage`. So SQL-heavy files never force-loaded the SL capture skill and defaulted to wiki capture.
2. **Preamble framing.** `memory_agent_external_ingest.md` framed every artifact as a reference doc and routed rules/definitions to the wiki, with no instruction to encode a *verified computation* as a measure/segment or to revise a scan-guessed source in place. The `do_not` "don't fabricate" line also read as a brake on encoding a query (a query implies a measure rather than declaring one).
3. **Re-run blindness.** The SL index shown to the agent on each re-run listed measures and joins but not segments, so repeat passes could not see which existing sources were thin on segments and re-derived non-deterministically.

## Changes (one commit each)

- `fix(memory): fire SL capture signal for SQL-bearing external ingest` — external ingest treats the deliberate submission itself as the substantive signal, so verified SQL fires the SL signal regardless of the boilerplate user message. Research/backfill keep the existing length gate. Adds two regression tests.
- `feat(memory): encode verified question/SQL pairs as executable measures and segments` — adds a `verified_pairs` directive (encode the computation, revise sources in place, verified material is authoritative over a conflicting scan guess), points the workflow at `sl_capture`, and clarifies that deriving a measure from a verified query is derivation from evidence, not fabrication.
- `fix(memory): surface segments in the SL index for re-run gap targeting` — the index now reports segment counts and names alongside measures, so a second pass targets gaps instead of re-deriving blindly; a source is only flagged for enrichment when measures, segments, and joins are all empty.

## Verification

- `pnpm --filter @kaelio/ktx run type-check` — clean
- `pnpm --filter @kaelio/ktx exec vitest run test/context/memory/` — 50 passed (incl. 2 new signal tests)
- `pnpm run dead-code` — clean (Biome + both Knip modes)

## Notes

- No new flags or runtime paths; the fix routes through the existing external-ingest preamble and shared signal detector.
- A deterministic upstream projection of verified pairs (sqlglot: aggregation→measure, filter→segment) would make one-pass coverage exhaustive rather than convergent, and is a sensible follow-up, but is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)