### PR TITLE
feat(snowflake): add OAuth token authentication

### DIFF
--- a/docs-site/content/docs/integrations/primary-sources.mdx
+++ b/docs-site/content/docs/integrations/primary-sources.mdx
@@ -118,7 +118,7 @@ This helps **ktx** understand how your team actually queries the data.
 
 ## Snowflake
 
-Connects via the Snowflake SDK. Supports multi-schema scanning, RSA key authentication, and query-history configuration for Snowflake query history.
+Connects via the Snowflake SDK. Supports multi-schema scanning, password, RSA key pair, and OAuth authentication, and query-history configuration for Snowflake query history.
 
 ### Connection config
 
@@ -146,8 +146,25 @@ single schema, `schema_name: PUBLIC` is accepted as an equivalent shorthand.
 
 | Method | Config |
 |--------|--------|
-| Password | `password: env:SNOWFLAKE_PASSWORD` |
+| Password (default) | `password: env:SNOWFLAKE_PASSWORD` |
 | RSA key pair | `authMethod: rsa`, `privateKey: file:~/.ssh/snowflake_key.pem`, optional `passphrase` |
+| OAuth | `authMethod: oauth`, `token_ref: env:SNOWFLAKE_OAUTH_TOKEN` |
+
+For OAuth, `username` is optional — the token carries identity. If your Snowflake account requires it alongside the token (e.g. for auditing), add `username` as normal.
+
+```yaml title="ktx.yaml — OAuth example"
+connections:
+  my-snowflake:
+    driver: snowflake
+    authMethod: oauth
+    account: xy12345
+    warehouse: ANALYTICS_WH
+    database: PROD
+    token_ref: env:SNOWFLAKE_OAUTH_TOKEN
+    role: ANALYST
+```
+
+`token_ref` follows the same reference syntax as other secrets: `env:VAR` reads from an environment variable, `file:/path/to/token` reads from a file (supports `~` expansion). A literal token value can be supplied directly with `token:`, but `token_ref` is preferred.
 
 ### Features
 

--- a/packages/cli/src/connectors/snowflake/connector.ts
+++ b/packages/cli/src/connectors/snowflake/connector.ts
@@ -33,7 +33,7 @@ import { configureSnowflakeSdkLogger } from './sdk-logger.js';
 
 export interface KtxSnowflakeConnectionConfig {
   driver?: string;
-  authMethod?: 'password' | 'rsa';
+  authMethod?: 'password' | 'rsa' | 'oauth';
   account?: string;
   warehouse?: string;
   database?: string;
@@ -43,21 +43,24 @@ export interface KtxSnowflakeConnectionConfig {
   password?: string;
   privateKey?: string;
   passphrase?: string;
+  token?: string;
+  token_ref?: string;
   role?: string;
   maxConnections?: number;
   [key: string]: unknown;
 }
 
 export interface KtxSnowflakeResolvedConnectionConfig {
-  authMethod: 'password' | 'rsa';
+  authMethod: 'password' | 'rsa' | 'oauth';
   account: string;
   warehouse: string;
   database: string;
   schemas: string[];
-  username: string;
+  username?: string;
   password?: string;
   privateKey?: string;
   passphrase?: string;
+  token?: string;
   role?: string;
   maxConnections: number;
 }
@@ -260,7 +263,8 @@ export function snowflakeConnectionConfigFromConfig(input: {
   if (!database) {
     throw new Error(`Native Snowflake connector requires connections.${input.connectionId}.database`);
   }
-  if (!username) {
+  // username is required for password/rsa; optional for oauth (token carries identity).
+  if (authMethod !== 'oauth' && !username) {
     throw new Error(`Native Snowflake connector requires connections.${input.connectionId}.username`);
   }
   assertSafeSnowflakeIdentifier(warehouse, 'warehouse');
@@ -275,7 +279,7 @@ export function snowflakeConnectionConfigFromConfig(input: {
     warehouse,
     database,
     schemas: resolvedSchemas,
-    username,
+    ...(username ? { username } : {}),
     maxConnections: positiveIntegerConfigValue({
       connection: input.connection,
       key: 'maxConnections',
@@ -297,6 +301,18 @@ export function snowflakeConnectionConfigFromConfig(input: {
     if (!resolved.privateKey) {
       throw new Error(`Native Snowflake connector requires connections.${input.connectionId}.privateKey for RSA auth`);
     }
+  } else if (authMethod === 'oauth') {
+    // token_ref is the preferred form; token accepts a literal value.
+    const tokenRef = input.connection?.token_ref;
+    const token = tokenRef
+      ? resolveStringReference(tokenRef as string, env)
+      : stringConfigValue(input.connection, 'token', env);
+    if (!token) {
+      throw new Error(
+        `Native Snowflake connector requires connections.${input.connectionId}.token_ref (or token) for OAuth auth`,
+      );
+    }
+    resolved.token = token;
   } else {
     resolved.password = stringConfigValue(input.connection, 'password', env);
     if (!resolved.password) {
@@ -488,9 +504,13 @@ class SnowflakeSdkDriver implements KtxSnowflakeDriver {
       clientSessionKeepAliveHeartbeatFrequency: 900,
       ...patch?.sdkOptions,
     };
-    return this.resolved.authMethod === 'rsa'
-      ? { ...baseConfig, authenticator: 'SNOWFLAKE_JWT', privateKey: this.decryptPrivateKey() }
-      : { ...baseConfig, password: this.resolved.password };
+    if (this.resolved.authMethod === 'rsa') {
+      return { ...baseConfig, authenticator: 'SNOWFLAKE_JWT', privateKey: this.decryptPrivateKey() };
+    }
+    if (this.resolved.authMethod === 'oauth') {
+      return { ...baseConfig, authenticator: 'OAUTH', token: this.resolved.token };
+    }
+    return { ...baseConfig, password: this.resolved.password };
   }
 
   private async executeSnowflakeQuery(

--- a/packages/cli/test/connectors/snowflake/connector.test.ts
+++ b/packages/cli/test/connectors/snowflake/connector.test.ts
@@ -194,6 +194,89 @@ describe('KtxSnowflakeScanConnector', () => {
     }
   });
 
+  it('resolves OAuth config with token_ref and does not require username', () => {
+    const resolved = snowflakeConnectionConfigFromConfig({
+      connectionId: 'warehouse',
+      connection: {
+        driver: 'snowflake',
+        authMethod: 'oauth',
+        account: 'acct',
+        warehouse: 'WH',
+        database: 'ANALYTICS',
+        token_ref: 'env:SNOWFLAKE_OAUTH_TOKEN',
+      },
+      env: { SNOWFLAKE_OAUTH_TOKEN: 'test-token-value' }, // pragma: allowlist secret
+    });
+    expect(resolved.authMethod).toBe('oauth');
+    expect(resolved.token).toBe('test-token-value');
+    expect(resolved.username).toBeUndefined();
+  });
+
+  it('resolves OAuth config with inline token', () => {
+    const resolved = snowflakeConnectionConfigFromConfig({
+      connectionId: 'warehouse',
+      connection: {
+        driver: 'snowflake',
+        authMethod: 'oauth',
+        account: 'acct',
+        warehouse: 'WH',
+        database: 'ANALYTICS',
+        token: 'inline-token', // pragma: allowlist secret
+      },
+    });
+    expect(resolved.authMethod).toBe('oauth');
+    expect(resolved.token).toBe('inline-token');
+  });
+
+  it('resolves OAuth config with optional username', () => {
+    const resolved = snowflakeConnectionConfigFromConfig({
+      connectionId: 'warehouse',
+      connection: {
+        driver: 'snowflake',
+        authMethod: 'oauth',
+        account: 'acct',
+        warehouse: 'WH',
+        database: 'ANALYTICS',
+        username: 'svc_account',
+        token_ref: 'env:SNOWFLAKE_OAUTH_TOKEN',
+      },
+      env: { SNOWFLAKE_OAUTH_TOKEN: 'test-token-value' }, // pragma: allowlist secret
+    });
+    expect(resolved.username).toBe('svc_account');
+    expect(resolved.token).toBe('test-token-value');
+  });
+
+  it('throws when OAuth config is missing token and token_ref', () => {
+    expect(() =>
+      snowflakeConnectionConfigFromConfig({
+        connectionId: 'warehouse',
+        connection: {
+          driver: 'snowflake',
+          authMethod: 'oauth',
+          account: 'acct',
+          warehouse: 'WH',
+          database: 'ANALYTICS',
+        },
+      }),
+    ).toThrow('connections.warehouse.token_ref');
+  });
+
+  it('throws when password auth is missing username', () => {
+    expect(() =>
+      snowflakeConnectionConfigFromConfig({
+        connectionId: 'warehouse',
+        connection: {
+          driver: 'snowflake',
+          authMethod: 'password',
+          account: 'acct',
+          warehouse: 'WH',
+          database: 'ANALYTICS',
+          password: 'fixture-pass', // pragma: allowlist secret
+        },
+      }),
+    ).toThrow('connections.warehouse.username');
+  });
+
   it('rejects stale Snowflake pool config key', () => {
     const baseConnection: KtxSnowflakeConnectionConfig = {
       driver: 'snowflake',


### PR DESCRIPTION
## Summary

Adds `authMethod: oauth` to the Snowflake connector alongside the existing `password` and `rsa` methods.

The Snowflake SDK supports OAuth via `authenticator: 'OAUTH'` and a bearer token. This change wires that up as a first-class auth method in **ktx**, following the same pattern as `password` and `rsa`:

- `token_ref` accepts any reference the existing `resolveStringReference` helper understands: `env:VAR`, `file:/path/to/token` (with `~` expansion), or a plain literal via `token:`
- `username` is optional for OAuth — the token carries identity. It is accepted when present (some Snowflake account configurations require it alongside the token for auditing)
- All other fields (`account`, `warehouse`, `database`, `schema_names`, `role`, `maxConnections`) behave identically to the other auth methods

```yaml
connections:
  my-snowflake:
    driver: snowflake
    authMethod: oauth
    account: xy12345
    warehouse: ANALYTICS_WH
    database: PROD
    token_ref: env:SNOWFLAKE_OAUTH_TOKEN
    role: ANALYST
```

## Implementation notes

The `KtxSnowflakeSdkOptionsProvider` extension point already existed for injecting arbitrary SDK options at runtime. OAuth is implemented at a lower level — in `snowflakeConnectionConfigFromConfig` and `resolveConnectionOptions` — because the token is a first-class connection credential rather than a runtime patch, and it needs the same validation and error messaging as `password` and `privateKey`.

`username` being optional only for `oauth` preserves the existing strict requirement for `password` and `rsa`, where username is always required.

## Test plan

- `resolves OAuth config with token_ref` — env reference resolved correctly, no username required
- `resolves OAuth config with inline token` — literal token accepted
- `resolves OAuth config with optional username` — username round-trips when provided
- `throws when OAuth config is missing token and token_ref` — clear error message
- `throws when password auth is missing username` — existing requirement preserved (regression guard)

All 18 Snowflake connector tests pass. Type-check and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)