### PR TITLE
docs: improve CLI flags table readability

### DIFF
--- a/docs-site/content/docs/cli-reference/ktx-setup.mdx
+++ b/docs-site/content/docs/cli-reference/ktx-setup.mdx
@@ -29,9 +29,17 @@ below.
 | `--agents` | Install agent configuration and rules only | `false` |
 | `--target <target>` | Agent target: `claude-code`, `claude-desktop`, `codex`, `cursor`, `opencode`, or `universal` | — |
 | `--global` | Install agent integration into the global target scope for `claude-code` or `codex` | `false` |
-| `--install-dir <path>` | Directory for project-scoped agent config. Resolved against the current directory. | project directory |
-| `--yes` | Accept project creation and runtime install defaults when setup asks for confirmation | `false` |
+| `--install-dir <path>` | Install project-scoped agent configuration | `ktx project dir` |
+| `--yes` | Accept project creation and runtime install defaults where setup asks for confirmation | `false` |
 | `--no-input` | Disable interactive terminal input | — |
+
+> **`--install-dir <path>`**
+>
+> Installs project-scoped agent configuration into the specified directory.
+> The path is resolved against the current directory and created if it doesn't
+> exist. Use it to install `.claude/`, `.mcp.json`, and rules where you open
+> your agent (for example, `--install-dir .`). This option is mutually exclusive
+> with `--global` and `--local`.
 
 Use the global `--project-dir <path>` option when setup should target a
 specific directory.

--- a/docs-site/content/docs/cli-reference/ktx-setup.mdx
+++ b/docs-site/content/docs/cli-reference/ktx-setup.mdx
@@ -27,11 +27,11 @@ below.
 | Flag | Description | Default |
 |------|-------------|---------|
 | `--agents` | Install agent configuration and rules only | `false` |
-| `--target <target>` | Agent target: `claude-code`, `claude-desktop`, `codex`, `cursor`, `opencode`, or `universal` | — |
+| `--target <target>` | Agent target: `claude-code`, `claude-desktop`, `codex`, `cursor`, `opencode`, or `universal` | - |
 | `--global` | Install agent integration into the global target scope for `claude-code` or `codex` | `false` |
-| `--install-dir <path>` | Install project-scoped agent configuration | `ktx project dir` |
+| `--install-dir <path>` | Install project-scoped agent configuration | ktx project dir |
 | `--yes` | Accept project creation and runtime install defaults where setup asks for confirmation | `false` |
-| `--no-input` | Disable interactive terminal input | — |
+| `--no-input` | Disable interactive terminal input | - |
 
 > **`--install-dir <path>`**
 >

--- a/docs-site/content/docs/cli-reference/ktx-setup.mdx
+++ b/docs-site/content/docs/cli-reference/ktx-setup.mdx
@@ -27,11 +27,11 @@ below.
 | Flag | Description | Default |
 |------|-------------|---------|
 | `--agents` | Install agent configuration and rules only | `false` |
-| `--target <target>` | Agent target: `claude-code`, `claude-desktop`, `codex`, `cursor`, `opencode`, or `universal` | - |
+| `--target <target>` | Agent target: `claude-code`, `claude-desktop`, `codex`, `cursor`, `opencode`, or `universal` | — |
 | `--global` | Install agent integration into the global target scope for `claude-code` or `codex` | `false` |
-| `--install-dir <path>` | Directory to install project-scoped agent config into. Defaults to the ktx project directory; resolved against the current directory and created if missing. Use it to install `.claude/`, `.mcp.json`, and rules where you open your agent (e.g. `--install-dir .`). Mutually exclusive with `--global` and `--local` | ktx project dir |
-| `--yes` | Accept project creation and runtime install defaults where setup asks for confirmation | `false` |
-| `--no-input` | Disable interactive terminal input | - |
+| `--install-dir <path>` | Directory for project-scoped agent config. Resolved against the current directory. | project directory |
+| `--yes` | Accept project creation and runtime install defaults when setup asks for confirmation | `false` |
+| `--no-input` | Disable interactive terminal input | — |
 
 Use the global `--project-dir <path>` option when setup should target a
 specific directory.


### PR DESCRIPTION
Before:

<img width="1163" height="820" alt="Screenshot 2026-06-29 010644" src="https://github.com/user-attachments/assets/8bd5dd67-e7d3-4a22-a42b-6da6aea3faa6" />

After:

<img width="1287" height="865" alt="image" src="https://github.com/user-attachments/assets/63802a35-4eb1-4fac-a0cd-f2dd5becefdc" />
