### PR TITLE
feat(docs): add system theme option to theme toggle

### DIFF
--- a/docs-site/components/theme-toggle.tsx
+++ b/docs-site/components/theme-toggle.tsx
@@ -55,8 +55,28 @@ function MoonIcon(props: SVGProps<SVGSVGElement>) {
   );
 }
 
+function MonitorIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      {...props}
+    >
+      <rect x="3" y="4" width="18" height="12" rx="2" />
+      <path d="M8 20h8" />
+      <path d="M12 16v4" />
+    </svg>
+  );
+}
+
 const OPTIONS = [
   ["light", SunIcon],
+  ["system", MonitorIcon],
   ["dark", MoonIcon],
 ] as const;
 
@@ -65,14 +85,22 @@ function cx(...classes: (string | false | undefined)[]): string {
 }
 
 export function ThemeToggle({ className, ...props }: ComponentProps<"div">) {
-  const { setTheme, resolvedTheme } = useTheme();
+  const { theme, setTheme } = useTheme();
+
   const [mounted, setMounted] = useState(false);
-  useEffect(() => setMounted(true), []);
-  const active = mounted ? resolvedTheme : null;
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const active = mounted ? theme : null;
 
   return (
     <div
-      className={cx("inline-flex items-center overflow-hidden border", className)}
+      className={cx(
+        "inline-flex items-center overflow-hidden border",
+        className,
+      )}
       data-theme-toggle=""
       {...props}
     >
@@ -81,6 +109,7 @@ export function ThemeToggle({ className, ...props }: ComponentProps<"div">) {
           key={key}
           type="button"
           aria-label={key}
+          aria-pressed={active === key}
           onClick={() => setTheme(key)}
           className={cx(
             "size-6.5 p-1.5 transition-colors",

--- a/docs-site/components/theme-toggle.tsx
+++ b/docs-site/components/theme-toggle.tsx
@@ -1,14 +1,24 @@
 "use client";
 
-import { useEffect, useState, type ComponentProps, type SVGProps } from "react";
+import {
+  useEffect,
+  useRef,
+  useState,
+  type ComponentProps,
+  type KeyboardEvent,
+  type SVGProps,
+} from "react";
 import { useTheme } from "fumadocs-ui/provider/base";
 
 /**
- * Two-icon theme switcher (light / dark), each icon selecting its own theme —
- * unlike fumadocs' default "light-dark" switcher, which is a single blind
- * toggle that flips on any click. Dropped into the sidebar footer pill via
- * `slots.themeSwitch`, so fumadocs passes the container className (left
- * divider, `ms-auto`, rounded inner buttons); we merge it onto our own base.
+ * Three-icon theme switcher (light / system / dark) rendered as a radio group —
+ * each icon selects its own theme, unlike fumadocs' default "light-dark"
+ * switcher, which is a single blind toggle that flips on any click. Reads
+ * `theme`, not `resolvedTheme`, so the "system" option can show as selected
+ * (resolvedTheme collapses system to light/dark). Dropped into the sidebar
+ * footer pill via `slots.themeSwitch`, so fumadocs passes the container
+ * className (left divider, `ms-auto`, rounded inner buttons); we merge it onto
+ * our own base.
  *
  * Icons are inlined (the project doesn't depend on `lucide-react` directly);
  * `useTheme` is re-exported by fumadocs so we avoid a bare `next-themes` import.
@@ -38,23 +48,6 @@ function SunIcon(props: SVGProps<SVGSVGElement>) {
   );
 }
 
-function MoonIcon(props: SVGProps<SVGSVGElement>) {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth={2}
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      aria-hidden="true"
-      {...props}
-    >
-      <path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z" />
-    </svg>
-  );
-}
-
 function MonitorIcon(props: SVGProps<SVGSVGElement>) {
   return (
     <svg
@@ -74,6 +67,23 @@ function MonitorIcon(props: SVGProps<SVGSVGElement>) {
   );
 }
 
+function MoonIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      {...props}
+    >
+      <path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z" />
+    </svg>
+  );
+}
+
 const OPTIONS = [
   ["light", SunIcon],
   ["system", MonitorIcon],
@@ -86,31 +96,52 @@ function cx(...classes: (string | false | undefined)[]): string {
 
 export function ThemeToggle({ className, ...props }: ComponentProps<"div">) {
   const { theme, setTheme } = useTheme();
-
   const [mounted, setMounted] = useState(false);
-
-  useEffect(() => {
-    setMounted(true);
-  }, []);
-
+  useEffect(() => setMounted(true), []);
   const active = mounted ? theme : null;
+
+  const buttonsRef = useRef<(HTMLButtonElement | null)[]>([]);
+
+  // Pre-mount nothing is selected, so keep the first control tabbable.
+  const selectedIndex = OPTIONS.findIndex(([key]) => key === active);
+  const rovingIndex = selectedIndex === -1 ? 0 : selectedIndex;
+
+  // Radio-group keyboard model: arrows move focus and pick that theme.
+  function onKeyDown(event: KeyboardEvent<HTMLButtonElement>, index: number) {
+    const delta =
+      event.key === "ArrowRight" || event.key === "ArrowDown"
+        ? 1
+        : event.key === "ArrowLeft" || event.key === "ArrowUp"
+          ? -1
+          : 0;
+    if (delta === 0) return;
+    event.preventDefault();
+    const next = (index + delta + OPTIONS.length) % OPTIONS.length;
+    setTheme(OPTIONS[next][0]);
+    buttonsRef.current[next]?.focus();
+  }
 
   return (
     <div
-      className={cx(
-        "inline-flex items-center overflow-hidden border",
-        className,
-      )}
+      className={cx("inline-flex items-center overflow-hidden border", className)}
       data-theme-toggle=""
+      role="radiogroup"
+      aria-label="Theme"
       {...props}
     >
-      {OPTIONS.map(([key, Icon]) => (
+      {OPTIONS.map(([key, Icon], index) => (
         <button
           key={key}
+          ref={(el) => {
+            buttonsRef.current[index] = el;
+          }}
           type="button"
+          role="radio"
           aria-label={key}
-          aria-pressed={active === key}
+          aria-checked={active === key}
+          tabIndex={index === rovingIndex ? 0 : -1}
           onClick={() => setTheme(key)}
+          onKeyDown={(event) => onKeyDown(event, index)}
           className={cx(
             "size-6.5 p-1.5 transition-colors",
             active === key


### PR DESCRIPTION
## Summary

Adds a **System** theme option in the docs page  theme toggle with the existing **Light** and **Dark** modes.

## Changes

* Add a monitor icon to represent the system theme.
* Add a `system` option to the theme switcher.

## Why

Many users prefer following their operating system's appearance settings. This change allows switching between **Light**, **Dark**, and **System** modes while correctly indicating the selected theme.


https://github.com/user-attachments/assets/d3709129-68eb-4807-8bbd-5c1f3c59c6ad

