### PR TITLE
docs: reflect recently added connectors in ingestion diagram and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,9 @@ upkeep and don't absorb the rest of your company's knowledge.
 - You don't have a SQL warehouse - **ktx** sits on top of one
 - You only need one ad-hoc query - `psql` or a notebook will do
 
-Works with PostgreSQL, Snowflake, BigQuery, ClickHouse, MySQL, SQL Server, and
-SQLite. Integrates with dbt, MetricFlow, LookML, Looker, Metabase, and Notion.
+Works with PostgreSQL, Snowflake, BigQuery, ClickHouse, MySQL, SQL Server,
+SQLite, DuckDB, Amazon Athena, and MongoDB. Integrates with dbt, MetricFlow,
+LookML, Looker, Metabase, Sigma, Notion, and Google Drive.
 
 ## Quick Start
 

--- a/docs-site/components/product-mechanics.tsx
+++ b/docs-site/components/product-mechanics.tsx
@@ -68,14 +68,14 @@ const EDGE_STROKE = "#94a3b8";
 const sourceData: SourceNodeData[] = [
   {
     title: "Databases",
-    body: "Schemas, columns, keys, row counts, and query history.",
-    items: ["PostgreSQL", "Snowflake", "BigQuery", "SQLite"],
+    body: "Schemas, keys, row counts, query history.",
+    items: ["PostgreSQL", "Snowflake", "BigQuery", "Athena", "MongoDB", "& more"],
     accent: "#3b82f6",
   },
   {
     title: "BI tools",
     body: "Dashboards, questions, explores, usage, and trusted examples.",
-    items: ["Metabase", "Looker"],
+    items: ["Metabase", "Looker", "Sigma"],
     accent: "#f97316",
   },
   {
@@ -87,7 +87,7 @@ const sourceData: SourceNodeData[] = [
   {
     title: "Docs and notes",
     body: "Policies, caveats, team definitions, and analyst context.",
-    items: ["Notion", "Any text"],
+    items: ["Notion", "Google Drive", "Any text"],
     accent: "#10b981",
   },
 ];


### PR DESCRIPTION
## What

The ingestion diagram and the README connector summary had drifted from the
current connector set. Recently added connectors were missing:
**Amazon Athena, MongoDB, DuckDB, Sigma, Google Drive**.

The reference pages (`integrations/primary-sources.mdx`,
`integrations/context-sources.mdx`) were already current; only the diagram and
README summary needed updating.

## Changes

- **Ingestion diagram** (`docs-site/components/product-mechanics.tsx`): source
  cards had explicit chips with no catch-all, so they read as an exhaustive but
  stale list. Added **Athena** and **MongoDB** (plus a `& more` chip) to
  Databases, **Sigma** to BI tools, and **Google Drive** to Docs and notes.
  - The extra Databases chip pushed a third row that clipped the fixed-height
    card (`scrollHeight 230 > clientHeight 216`). Trimmed the card body to one
    line so all chips fit. Verified with a headless render: `clipped: false` on
    all four cards.
- **README** (`README.md`): the "Works with" summary was an exhaustive list with
  no catch-all. Added DuckDB, Amazon Athena, MongoDB, Sigma, and Google Drive so
  it matches the integrations reference pages.

## Not changed

- The README ingestion PNG (generated from `diagram-studio/flows.ts`) already
  ends every card in `· …`, so it is not misleading and was left as is. If we
  want the new names shown there too, it needs a re-export from
  `/diagram-studio`.

## Verification

- Rendered the live diagram via the dev server and confirmed no clipping across
  all source cards (screenshots + programmatic `scrollHeight`/`clientHeight`
  check).
- `docs-site` route tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)