### PR TITLE
feat(sharepoint): add SharePoint context source support

### DIFF
--- a/docs-site/content/docs/configuration/ktx-yaml.mdx
+++ b/docs-site/content/docs/configuration/ktx-yaml.mdx
@@ -36,7 +36,7 @@ read, how to think, and where to put the results.
         Inputs
       </p>
       <ul className="mt-3 space-y-2 text-sm leading-6 text-fd-foreground">
-        <li><code className="text-[13px] font-semibold">connections</code> - warehouses, BI tools, dbt, Notion</li>
+        <li><code className="text-[13px] font-semibold">connections</code> - warehouses, BI tools, dbt, Notion, SharePoint</li>
         <li><code className="text-[13px] font-semibold">setup</code> - which connections are primary databases</li>
       </ul>
     </div>
@@ -89,7 +89,8 @@ secrets out of `ktx.yaml` so the file can stay in git.
 | Literal string | Used as-is | Non-secret values such as `base_url` |
 
 References work in: warehouse `url`, Metabase `api_key` / `api_key_ref`, Looker
-`client_secret` / `client_secret_ref`, Notion / dbt / LookML / MetricFlow
+`client_secret` / `client_secret_ref`, SharePoint `tenant_id_ref` /
+`client_id_ref` / `client_secret_ref`, Notion / dbt / LookML / MetricFlow
 `auth_token` / `auth_token_ref`, and any `api_key` under the `llm` and
 `ingest.embeddings` blocks.
 
@@ -120,6 +121,7 @@ context-source drivers share the map.
 | `dbt` | Context source | `driver`, one of `source_dir` or `repo_url` | `branch`, `path`, `profiles_path`, `target`, `project_name` |
 | `metricflow` | Context source | `driver`, `metricflow.repoUrl` | `metricflow.branch`, `metricflow.path`, `metricflow.auth_token_ref` |
 | `notion` | Context source | `driver`, `auth_token_ref` | `crawl_mode`, `root_*_ids`, `max_*_per_run` |
+| `sharepoint` | Context source | `driver`, `tenant_id_ref`, `client_id_ref`, `client_secret_ref`, `drive_id`, `folder_id` | `recursive` |
 | `sigma` | Context source | `driver`, `client_id`, `client_secret_ref` | `api_url` |
 
 ### Warehouse drivers
@@ -382,6 +384,31 @@ connections:
 | `max_knowledge_creates_per_run` | Max new wiki pages created per run (0-25). |
 | `max_knowledge_updates_per_run` | Max existing wiki pages updated per run (0-100). |
 
+### SharePoint / OneDrive
+
+```yaml
+connections:
+  sharepoint-docs:
+    driver: sharepoint
+    tenant_id_ref: env:AZURE_TENANT_ID
+    client_id_ref: env:AZURE_CLIENT_ID
+    client_secret_ref: env:AZURE_CLIENT_SECRET
+    drive_id: your-drive-id
+    folder_id: your-folder-id
+    recursive: false
+```
+
+| Field | Purpose |
+|-------|---------|
+| `tenant_id_ref` | Environment reference for the Azure tenant id. Required. |
+| `client_id_ref` | Environment reference for the Azure client id. Required. |
+| `client_secret_ref` | Environment reference for the Azure client secret. Required. |
+| `drive_id` | Microsoft Graph drive id for the SharePoint document library or OneDrive drive. Required. |
+| `folder_id` | Microsoft Graph folder item id to ingest. Required. |
+| `recursive` | Traverse subfolders under `folder_id`. Default: `false`. |
+
+SharePoint credentials use `env:` references only in v1. `file:` refs and inline secrets are not accepted for this driver. The Azure AD app must have Microsoft Graph application permissions `Files.Read.All` and `Sites.Read.All` with admin consent.
+
 ### Sigma
 
 ```yaml
@@ -568,6 +595,7 @@ connector that **ktx** ships locally:
 | `looker` | Looker dashboards and looks via the API. |
 | `metabase` | Metabase cards, dashboards, and database mappings. |
 | `notion` | Notion pages and databases for wiki context. |
+| `sharepoint` | SharePoint document libraries or OneDrive folders for wiki context. |
 | `fake` | Test/demo connector. Useful in fixtures. |
 
 ### Embeddings

--- a/docs-site/content/docs/integrations/context-sources.mdx
+++ b/docs-site/content/docs/integrations/context-sources.mdx
@@ -1,6 +1,6 @@
 ---
 title: Context Sources
-description: Ingest semantic context from dbt, MetricFlow, LookML, Metabase, Looker, Notion, Sigma, and Google Drive.
+description: Ingest semantic context from dbt, MetricFlow, LookML, Metabase, Looker, Notion, Sigma, Google Drive, and SharePoint / OneDrive.
 ---
 
 Context sources feed your existing analytics tooling into **ktx**. During ingestion, **ktx** extracts metadata from each source and uses a reconciliation agent to reconcile it with your existing semantic layer and knowledge base - preserving accepted edits rather than overwriting.
@@ -27,7 +27,7 @@ LookML uses top-level `repoUrl`, and MetricFlow uses nested
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `driver` | Yes | Source connector: `dbt`, `metricflow`, `lookml`, `metabase`, `looker`, `notion`, `sigma`, or `gdrive` |
+| `driver` | Yes | Source connector: `dbt`, `metricflow`, `lookml`, `metabase`, `looker`, `notion`, `sigma`, `gdrive`, or `sharepoint` |
 | `source_dir` | For local file sources | Absolute or project-relative source directory |
 | `repo_url` | For Git-hosted dbt sources | Git repository URL |
 | `repoUrl` | For Git-hosted LookML sources | Git repository URL |
@@ -536,6 +536,72 @@ connections:
 - `ktx connection test <connectionId>` supports `gdrive`: it verifies that `folder_id` resolves to a folder the service account can read, then reports the number of Google Docs visible in it. A wrong or unshared `folder_id` fails the test instead of reporting zero docs
 - Only Google Docs are ingested in v1; other file types (Sheets, Slides, PDFs) in the folder are skipped and recorded in the staged manifest
 - The service account must be granted access to the target folder explicitly
+
+---
+
+## SharePoint / OneDrive
+
+Ingests Markdown and Word documents from a Microsoft Graph drive folder. The drive can belong to either a SharePoint document library or a OneDrive account. This v1 implementation is knowledge-only.
+
+### What it provides
+
+- Wiki pages synthesized from SharePoint and OneDrive documents
+- Folder-scoped knowledge ingest from a specific Microsoft Graph `drive_id` + `folder_id`
+- Native Markdown passthrough for `.md` files and Markdown conversion for `.docx` files
+
+### Connection config
+
+```yaml title="ktx.yaml"
+connections:
+  company-docs:
+    driver: sharepoint
+    tenant_id_ref: env:AZURE_TENANT_ID
+    client_id_ref: env:AZURE_CLIENT_ID
+    client_secret_ref: env:AZURE_CLIENT_SECRET
+    drive_id: your-drive-id
+    folder_id: your-folder-id
+    recursive: false
+```
+
+### Authentication
+
+| Method | Config |
+|--------|--------|
+| Azure AD client credentials | `tenant_id_ref`, `client_id_ref`, `client_secret_ref` as `env:NAME` |
+
+SharePoint uses `env:` references only for credentials in v1. `file:` refs and inline secrets are rejected for this driver.
+
+### Required Microsoft Graph application permissions
+
+Grant these application permissions to the Azure AD app and complete admin consent:
+
+- `Files.Read.All`
+- `Sites.Read.All`
+
+### Configuration options
+
+| Field | Description | Default |
+|-------|-------------|---------|
+| `tenant_id_ref` | Environment reference for the Azure tenant id | - |
+| `client_id_ref` | Environment reference for the Azure client id | - |
+| `client_secret_ref` | Environment reference for the Azure client secret | - |
+| `drive_id` | Microsoft Graph drive id to ingest | - |
+| `folder_id` | Microsoft Graph folder item id to ingest | - |
+| `recursive` | Traverse subfolders under `folder_id` | `false` |
+
+### What gets ingested
+
+- `.md` and `.docx` files only
+- Wiki-oriented knowledge content
+- One work unit per staged document
+
+### Notes
+
+- `sharepoint` is knowledge-only in v1; it does not produce semantic-layer sources
+- `ktx setup` supports SharePoint configuration, including the credential refs, drive id, folder id, optional site-id-assisted drive discovery, and recursive crawl flag
+- `ktx connection test <connectionId>` supports `sharepoint`: it verifies that `folder_id` resolves to a readable folder, then reports the number of supported docs visible in it
+- Other file types in the folder are skipped and recorded in the staged manifest
+- Runtime ingest is drive-folder centric: SharePoint document libraries and OneDrive folders both use `drive_id` + `folder_id`
 
 ## Common errors
 

--- a/packages/cli/src/commands/setup-commands.ts
+++ b/packages/cli/src/commands/setup-commands.ts
@@ -60,7 +60,8 @@ function sourceType(value: string): KtxSetupSourceType {
     value === 'lookml' ||
     value === 'notion' ||
     value === 'sigma' ||
-    value === 'gdrive'
+    value === 'gdrive' ||
+    value === 'sharepoint'
   ) {
     return value;
   }
@@ -138,6 +139,13 @@ function shouldShowSetupEntryMenu(
     gdriveServiceAccountKeyRef?: string;
     gdriveFolderId?: string;
     gdriveRecursive?: boolean;
+    sharepointTenantIdRef?: string;
+    sharepointClientIdRef?: string;
+    sharepointClientSecretRef?: string;
+    sharepointDriveId?: string;
+    sharepointFolderId?: string;
+    sharepointRecursive?: boolean;
+    sharepointSiteId?: string;
     skipSources?: boolean;
   },
   command: Command,
@@ -206,6 +214,13 @@ function shouldShowSetupEntryMenu(
     'gdriveServiceAccountKeyRef',
     'gdriveFolderId',
     'gdriveRecursive',
+    'sharepointTenantIdRef',
+    'sharepointClientIdRef',
+    'sharepointClientSecretRef',
+    'sharepointDriveId',
+    'sharepointFolderId',
+    'sharepointRecursive',
+    'sharepointSiteId',
     'skipSources',
   ].some((optionName) => optionWasSpecified(command, optionName));
 }
@@ -352,6 +367,13 @@ export function registerSetupCommands(program: Command, context: KtxCliCommandCo
     )
     .addOption(new Option('--gdrive-folder-id <id>', 'Google Drive folder id to ingest').hideHelp())
     .addOption(new Option('--gdrive-recursive', 'Recursively traverse Google Drive subfolders').hideHelp().default(false))
+    .addOption(new Option('--sharepoint-tenant-id-ref <ref>', 'env: reference to the Azure tenant id').hideHelp())
+    .addOption(new Option('--sharepoint-client-id-ref <ref>', 'env: reference to the Azure client id').hideHelp())
+    .addOption(new Option('--sharepoint-client-secret-ref <ref>', 'env: reference to the Azure client secret').hideHelp())
+    .addOption(new Option('--sharepoint-drive-id <id>', 'Microsoft Graph drive id to ingest').hideHelp())
+    .addOption(new Option('--sharepoint-folder-id <id>', 'Microsoft Graph folder item id to ingest').hideHelp())
+    .addOption(new Option('--sharepoint-recursive', 'Recursively traverse SharePoint / OneDrive subfolders').hideHelp().default(false))
+    .addOption(new Option('--sharepoint-site-id <id>', 'Optional Microsoft Graph site id used only to discover drives during setup').hideHelp())
     .addOption(new Option('--skip-sources', 'Mark optional source setup complete with no sources').hideHelp().default(false))
     .showHelpAfterError();
 
@@ -506,6 +528,13 @@ export function registerSetupCommands(program: Command, context: KtxCliCommandCo
         : {}),
       ...(options.gdriveFolderId ? { gdriveFolderId: options.gdriveFolderId } : {}),
       ...(options.gdriveRecursive ? { gdriveRecursive: true } : {}),
+      ...(options.sharepointTenantIdRef ? { sharepointTenantIdRef: options.sharepointTenantIdRef } : {}),
+      ...(options.sharepointClientIdRef ? { sharepointClientIdRef: options.sharepointClientIdRef } : {}),
+      ...(options.sharepointClientSecretRef ? { sharepointClientSecretRef: options.sharepointClientSecretRef } : {}),
+      ...(options.sharepointDriveId ? { sharepointDriveId: options.sharepointDriveId } : {}),
+      ...(options.sharepointFolderId ? { sharepointFolderId: options.sharepointFolderId } : {}),
+      ...(options.sharepointRecursive ? { sharepointRecursive: true } : {}),
+      ...(options.sharepointSiteId ? { sharepointSiteId: options.sharepointSiteId } : {}),
       runInitialSourceIngest: false,
       skipSources: options.skipSources === true,
       showEntryMenu: shouldShowSetupEntryMenu(options, command),

--- a/packages/cli/src/connection.ts
+++ b/packages/cli/src/connection.ts
@@ -4,10 +4,13 @@ import type { LookerClient } from './context/ingest/adapters/looker/client.js';
 import type { MetabaseRuntimeClient } from './context/ingest/adapters/metabase/client-port.js';
 import { type NotionBotInfo, NotionClient } from './context/ingest/adapters/notion/notion-client.js';
 import { parseGdriveConnectionConfig, resolveGdriveServiceAccountKey } from './context/connections/gdrive-config.js';
+import { parseSharepointConnectionConfig, sharepointConnectionToPullConfig } from './context/connections/sharepoint-config.js';
 import { createLocalLookerCredentialResolver } from './context/ingest/adapters/looker/local-looker.adapter.js';
 import { metabaseRuntimeConfigFromLocalConnection } from './context/ingest/adapters/metabase/local-metabase.adapter.js';
 import { createGoogleDocsClients, verifyGdriveFolderAndCountDocs } from './context/ingest/adapters/gdrive/gdrive-client.js';
 import { gdriveServiceAccountKeySchema } from './context/ingest/adapters/gdrive/types.js';
+import { SHAREPOINT_ALLOWED_EXTENSIONS } from './context/ingest/adapters/sharepoint/types.js';
+import { SharepointGraphClient, createSharepointGraphClient } from './context/ingest/adapters/sharepoint/graph-client.js';
 import { testRepoConnection } from './context/ingest/repo-fetch.js';
 import { federatedConnectionListing } from './context/connections/federation.js';
 import { getDriverRegistration } from './context/connections/drivers.js';
@@ -38,6 +41,7 @@ type GdriveTestPort = Pick<
   ReturnType<typeof createGoogleDocsClients>['drive'],
   'listFiles' | 'getFile'
 >;
+type SharepointTestPort = Pick<SharepointGraphClient, 'getDriveItem' | 'listDriveFiles'>;
 type TestRepoConnection = typeof testRepoConnection;
 
 export interface KtxConnectionDeps {
@@ -46,6 +50,7 @@ export interface KtxConnectionDeps {
   createLookerClient?: (project: KtxLocalProject, connectionId: string) => Promise<LookerTestPort>;
   createNotionClient?: (project: KtxLocalProject, connectionId: string) => Promise<NotionTestPort>;
   createGdriveClient?: (project: KtxLocalProject, connectionId: string) => Promise<GdriveTestPort>;
+  createSharepointClient?: (project: KtxLocalProject, connectionId: string) => Promise<SharepointTestPort>;
   testRepoConnection?: TestRepoConnection;
 }
 
@@ -62,6 +67,7 @@ const SUPPORTED_TEST_DRIVERS = [
   'looker',
   'notion',
   'gdrive',
+  'sharepoint',
   'dbt',
   'metricflow',
   'lookml',
@@ -221,6 +227,46 @@ async function testGdriveConnection(
   return { docs: await verifyGdriveFolderAndCountDocs(client, parsed.folder_id) };
 }
 
+async function createDefaultSharepointClient(
+  project: KtxLocalProject,
+  connectionId: string,
+): Promise<SharepointTestPort> {
+  const connection = project.config.connections[connectionId];
+  if (!connection) {
+    throw new Error(`Connection "${connectionId}" is not configured in ktx.yaml`);
+  }
+  const parsed = parseSharepointConnectionConfig(connection);
+  return createSharepointGraphClient(await sharepointConnectionToPullConfig(parsed));
+}
+
+async function testSharepointConnection(
+  project: KtxLocalProject,
+  connectionId: string,
+  createClient: (project: KtxLocalProject, connectionId: string) => Promise<SharepointTestPort>,
+): Promise<{ docs: number }> {
+  const connection = project.config.connections[connectionId];
+  if (!connection) {
+    throw new Error(`Connection "${connectionId}" is not configured in ktx.yaml`);
+  }
+  const parsed = parseSharepointConnectionConfig(connection);
+  const client = await createClient(project, connectionId);
+  const folder = await client.getDriveItem(parsed.drive_id, parsed.folder_id);
+  if (!folder.folder) {
+    throw new Error(`SharePoint folder ${parsed.folder_id} is not accessible`);
+  }
+  const files = await client.listDriveFiles({
+    driveId: parsed.drive_id,
+    folderId: parsed.folder_id,
+    recursive: parsed.recursive,
+  });
+  const docs = files.filter(({ item }) => {
+    const dot = item.name.lastIndexOf('.');
+    const ext = dot >= 0 ? item.name.slice(dot).toLowerCase() : '';
+    return SHAREPOINT_ALLOWED_EXTENSIONS.has(ext);
+  }).length;
+  return { docs };
+}
+
 interface GitConnectionFields {
   repoUrl: string;
   authToken: string | null;
@@ -314,6 +360,15 @@ async function testConnectionByDriver(
       project,
       connectionId,
       deps.createGdriveClient ?? createDefaultGdriveClient,
+    );
+    return { driver, detailKey: 'Docs', detailValue: String(result.docs) };
+  }
+
+  if (driver === 'sharepoint') {
+    const result = await testSharepointConnection(
+      project,
+      connectionId,
+      deps.createSharepointClient ?? createDefaultSharepointClient,
     );
     return { driver, detailKey: 'Docs', detailValue: String(result.docs) };
   }

--- a/packages/cli/src/context/connections/sharepoint-config.ts
+++ b/packages/cli/src/context/connections/sharepoint-config.ts
@@ -1,0 +1,89 @@
+import type { KtxProjectConnectionConfig } from '../project/config.js';
+import type { SharepointPullConfig } from '../ingest/adapters/sharepoint/types.js';
+import { sharepointPullConfigSchema } from '../ingest/adapters/sharepoint/types.js';
+
+type RawKtxSharepointConnectionConfig = Extract<KtxProjectConnectionConfig, { driver: 'sharepoint' }>;
+
+export type KtxSharepointConnectionConfig = Omit<
+  RawKtxSharepointConnectionConfig,
+  'tenant_id_ref' | 'client_id_ref' | 'client_secret_ref' | 'drive_id' | 'folder_id' | 'recursive'
+> & {
+  driver: 'sharepoint';
+  tenant_id_ref: string;
+  client_id_ref: string;
+  client_secret_ref: string;
+  drive_id: string;
+  folder_id: string;
+  recursive: boolean;
+};
+
+interface ResolveSharepointOptions {
+  env?: Record<string, string | undefined>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function envRef(value: unknown, label: string): string {
+  const trimmed = typeof value === 'string' && value.trim().length > 0 ? value.trim() : null;
+  if (!trimmed) {
+    throw new Error(`sharepoint connection config requires ${label}`);
+  }
+  if (!trimmed.startsWith('env:')) {
+    throw new Error(`sharepoint ${label} must use env:NAME`);
+  }
+  return trimmed;
+}
+
+function stringField(value: unknown, label: string): string {
+  const trimmed = typeof value === 'string' && value.trim().length > 0 ? value.trim() : null;
+  if (!trimmed) {
+    throw new Error(`sharepoint connection config requires ${label}`);
+  }
+  return trimmed;
+}
+
+export function parseSharepointConnectionConfig(raw: unknown): KtxSharepointConnectionConfig {
+  if (!isRecord(raw)) {
+    throw new Error('sharepoint connection config must be an object');
+  }
+  if (raw.driver !== 'sharepoint') {
+    throw new Error('sharepoint connection config requires driver: sharepoint');
+  }
+  return {
+    driver: 'sharepoint',
+    tenant_id_ref: envRef(raw.tenant_id_ref, 'tenant_id_ref'),
+    client_id_ref: envRef(raw.client_id_ref, 'client_id_ref'),
+    client_secret_ref: envRef(raw.client_secret_ref, 'client_secret_ref'),
+    drive_id: stringField(raw.drive_id, 'drive_id'),
+    folder_id: stringField(raw.folder_id, 'folder_id'),
+    recursive: raw.recursive === true,
+  };
+}
+
+function resolveSharepointEnvRef(value: string, options: ResolveSharepointOptions = {}): string {
+  if (!value.startsWith('env:')) {
+    throw new Error('sharepoint credential refs must use env:NAME');
+  }
+  const name = value.slice('env:'.length);
+  const resolved = (options.env ?? process.env)[name];
+  if (!resolved || resolved.trim().length === 0) {
+    throw new Error(`SharePoint environment variable ${name} is not set`);
+  }
+  return resolved.trim();
+}
+
+export async function sharepointConnectionToPullConfig(
+  config: KtxSharepointConnectionConfig,
+  options: ResolveSharepointOptions = {},
+): Promise<SharepointPullConfig> {
+  return sharepointPullConfigSchema.parse({
+    tenantId: resolveSharepointEnvRef(config.tenant_id_ref, options),
+    clientId: resolveSharepointEnvRef(config.client_id_ref, options),
+    clientSecret: resolveSharepointEnvRef(config.client_secret_ref, options),
+    driveId: config.drive_id,
+    folderId: config.folder_id,
+    recursive: config.recursive,
+  });
+}

--- a/packages/cli/src/context/ingest/adapters/sharepoint/chunk.ts
+++ b/packages/cli/src/context/ingest/adapters/sharepoint/chunk.ts
@@ -1,0 +1,81 @@
+import { createHash } from 'node:crypto';
+import { readdir, readFile } from 'node:fs/promises';
+import { join, relative } from 'node:path';
+import type { ChunkResult, DiffSet, ScopeDescriptor, WorkUnit } from '../../types.js';
+import { sharepointManifestSchema, sharepointMetadataSchema } from './types.js';
+
+const SHAREPOINT_RECONCILE_GUIDANCE =
+  'Synthesize durable wiki knowledge from this SharePoint or OneDrive document. Preserve product definitions, process documentation, and operating rules as wiki pages. Do not create semantic-layer sources from sharepoint content in v1.';
+
+function normalizeRawPath(path: string): string {
+  return path.replace(/\\/g, '/');
+}
+
+async function walk(root: string): Promise<string[]> {
+  const entries = await readdir(root, { withFileTypes: true, recursive: true });
+  return entries
+    .filter((entry) => entry.isFile())
+    .map((entry) => normalizeRawPath(relative(root, join(entry.parentPath, entry.name))))
+    .sort();
+}
+
+function safeUnitKey(path: string): string {
+  return `sharepoint-${path.replace(/^docs\//, '').replace(/\/page\.md$/, '').replace(/[^a-zA-Z0-9]+/g, '-').replace(/^-+|-+$/g, '')}`;
+}
+
+async function readManifest(stagedDir: string) {
+  try {
+    return sharepointManifestSchema.parse(JSON.parse(await readFile(join(stagedDir, 'manifest.json'), 'utf-8')));
+  } catch (error) {
+    throw new Error(`Invalid sharepoint manifest: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+export async function chunkSharepointStagedDir(stagedDir: string, diffSet?: DiffSet): Promise<ChunkResult> {
+  const files = await walk(stagedDir);
+  const manifest = await readManifest(stagedDir);
+  const touched = diffSet ? new Set([...diffSet.added, ...diffSet.modified].map((path) => normalizeRawPath(path))) : null;
+  const workUnits: WorkUnit[] = [];
+
+  for (const pagePath of files.filter((path) => path.endsWith('/page.md'))) {
+    const metadataPath = pagePath.replace(/\/page\.md$/, '/metadata.json');
+    const primary = [metadataPath, pagePath].filter((path) => files.includes(path));
+    if (touched && !primary.some((path) => touched.has(path))) {
+      continue;
+    }
+    const metadata = sharepointMetadataSchema.parse(JSON.parse(await readFile(join(stagedDir, metadataPath), 'utf-8')));
+    const rawFiles = touched ? primary.filter((path) => touched.has(path)).sort() : primary.sort();
+    const dependencyPaths = ['manifest.json'].filter((path) => !rawFiles.includes(path));
+    const excluded = new Set([...rawFiles, ...dependencyPaths]);
+    const peerFileIndex = files.filter((path) => !excluded.has(path)).sort();
+    workUnits.push({
+      unitKey: safeUnitKey(pagePath),
+      displayLabel: metadata.path,
+      rawFiles,
+      dependencyPaths,
+      peerFileIndex,
+      notes: SHAREPOINT_RECONCILE_GUIDANCE,
+    });
+  }
+
+  return {
+    workUnits,
+    eviction:
+      diffSet && diffSet.deleted.length > 0
+        ? { deletedRawPaths: diffSet.deleted.map((path) => normalizeRawPath(path)).sort() }
+        : undefined,
+    reconcileNotes: ['SharePoint and OneDrive docs are knowledge-only in v1; keep output in wiki pages unless later follow-up work expands scope.'],
+    contextReport: { capped: false, warnings: manifest.warnings },
+  };
+}
+
+export async function describeSharepointScope(stagedDir: string): Promise<ScopeDescriptor> {
+  const manifest = await readManifest(stagedDir);
+  const fingerprint = createHash('sha256')
+    .update(JSON.stringify({ driveId: manifest.driveId, folderId: manifest.folderId, recursive: manifest.recursive }))
+    .digest('hex');
+  return {
+    fingerprint,
+    isPathInScope: (rawPath) => rawPath === 'manifest.json' || rawPath.startsWith('docs/'),
+  };
+}

--- a/packages/cli/src/context/ingest/adapters/sharepoint/detect.ts
+++ b/packages/cli/src/context/ingest/adapters/sharepoint/detect.ts
@@ -1,0 +1,20 @@
+import { readFile, readdir } from 'node:fs/promises';
+import { join } from 'node:path';
+
+export async function detectSharepointStagedDir(stagedDir: string): Promise<boolean> {
+  try {
+    const manifest = JSON.parse(await readFile(join(stagedDir, 'manifest.json'), 'utf-8')) as { source?: unknown };
+    if (manifest.source === 'sharepoint') {
+      return true;
+    }
+  } catch {
+    // Fall through to structural detection.
+  }
+
+  try {
+    const entries = await readdir(stagedDir, { withFileTypes: true, recursive: true });
+    return entries.some((entry) => entry.isFile() && entry.name === 'page.md');
+  } catch {
+    return false;
+  }
+}

--- a/packages/cli/src/context/ingest/adapters/sharepoint/docx-markdown.ts
+++ b/packages/cli/src/context/ingest/adapters/sharepoint/docx-markdown.ts
@@ -1,0 +1,148 @@
+import { unzipSync, strFromU8 } from 'fflate';
+
+interface NumberingLevel {
+  format: 'bullet' | 'decimal';
+}
+
+function decodeXmlText(value: string): string {
+  return value
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'");
+}
+
+function normalizeWhitespace(value: string): string {
+  return value.replace(/\r/g, '').replace(/[ \t]+\n/g, '\n').replace(/\n{3,}/g, '\n\n').trim();
+}
+
+function escapeMarkdownCell(value: string): string {
+  return value.replace(/\|/g, '\\|').replace(/\r?\n/g, ' ').trim();
+}
+
+function textFromRun(runXml: string): string {
+  if (/<w:tab(?:\s|\/>)/.test(runXml)) {
+    return '\t';
+  }
+  if (/<w:br(?:\s|\/>)/.test(runXml) || /<w:cr(?:\s|\/>)/.test(runXml)) {
+    return '\n';
+  }
+  const text = [...runXml.matchAll(/<w:t\b[^>]*>([\s\S]*?)<\/w:t>/g)].map((match) => decodeXmlText(match[1])).join('');
+  if (!text) {
+    return '';
+  }
+  const bold = /<w:b(?:\s|\/>)/.test(runXml);
+  const italic = /<w:i(?:\s|\/>)/.test(runXml);
+  let value = text;
+  if (bold) value = `**${value}**`;
+  if (italic) value = `_${value}_`;
+  return value;
+}
+
+function paragraphText(paragraphXml: string): string {
+  return normalizeWhitespace(
+    [...paragraphXml.matchAll(/<w:r\b[\s\S]*?<\/w:r>/g)]
+      .map((match) => textFromRun(match[0]))
+      .join('')
+      .replace(/\t/g, ' ')
+      .replace(/[ ]{2,}/g, ' '),
+  );
+}
+
+function parseNumbering(documentXml: string): Map<string, NumberingLevel> {
+  const abstractFormats = new Map<string, Map<number, NumberingLevel['format']>>();
+  for (const abstractMatch of documentXml.matchAll(/<w:abstractNum\b[\s\S]*?w:abstractNumId="(\d+)"[\s\S]*?<\/w:abstractNum>/g)) {
+    const levels = new Map<number, NumberingLevel['format']>();
+    for (const lvlMatch of abstractMatch[0].matchAll(/<w:lvl\b[\s\S]*?w:ilvl="(\d+)"[\s\S]*?<w:numFmt\b[^>]*w:val="([^"]+)"[^>]*\/?>[\s\S]*?<\/w:lvl>/g)) {
+      levels.set(Number.parseInt(lvlMatch[1], 10), lvlMatch[2] === 'bullet' ? 'bullet' : 'decimal');
+    }
+    abstractFormats.set(abstractMatch[1], levels);
+  }
+
+  const resolved = new Map<string, NumberingLevel>();
+  for (const numMatch of documentXml.matchAll(/<w:num\b[\s\S]*?w:numId="(\d+)"[\s\S]*?<w:abstractNumId\b[^>]*w:val="(\d+)"[^>]*\/?>[\s\S]*?<\/w:num>/g)) {
+    const formats = abstractFormats.get(numMatch[2]) ?? new Map<number, NumberingLevel['format']>();
+    for (const [level, format] of formats) {
+      resolved.set(`${numMatch[1]}:${level}`, { format });
+    }
+  }
+  return resolved;
+}
+
+function paragraphStyle(paragraphXml: string): string | null {
+  return paragraphXml.match(/<w:pStyle\b[^>]*w:val="([^"]+)"/)?.[1] ?? null;
+}
+
+function paragraphListInfo(paragraphXml: string): { numId: string; level: number } | null {
+  const numId = paragraphXml.match(/<w:numId\b[^>]*w:val="(\d+)"/)?.[1];
+  if (!numId) {
+    return null;
+  }
+  return { numId, level: Number.parseInt(paragraphXml.match(/<w:ilvl\b[^>]*w:val="(\d+)"/)?.[1] ?? '0', 10) };
+}
+
+function renderTable(tableXml: string): string {
+  const rows = [...tableXml.matchAll(/<w:tr\b[\s\S]*?<\/w:tr>/g)].map((rowMatch) =>
+    [...rowMatch[0].matchAll(/<w:tc\b[\s\S]*?<\/w:tc>/g)].map((cellMatch) => {
+      const cellParagraphs = [...cellMatch[0].matchAll(/<w:p\b[\s\S]*?<\/w:p>/g)]
+        .map((match) => paragraphText(match[0]))
+        .filter(Boolean);
+      return escapeMarkdownCell(cellParagraphs.join(' '));
+    }),
+  );
+  if (rows.length === 0) {
+    return '';
+  }
+  const columnCount = Math.max(...rows.map((row) => row.length), 1);
+  const normalized = rows.map((row) => [...row, ...Array.from({ length: columnCount - row.length }, () => '')]);
+  return [
+    `| ${normalized[0].join(' | ')} |`,
+    `| ${Array.from({ length: columnCount }, () => '---').join(' | ')} |`,
+    ...normalized.slice(1).map((row) => `| ${row.join(' | ')} |`),
+  ].join('\n');
+}
+
+export function convertDocxToMarkdown(buffer: Buffer): string {
+  const archive = unzipSync(new Uint8Array(buffer));
+  const documentXml = archive['word/document.xml'] ? strFromU8(archive['word/document.xml']) : '';
+  const numberingXml = archive['word/numbering.xml'] ? strFromU8(archive['word/numbering.xml']) : '';
+  if (!documentXml) {
+    return '';
+  }
+  const numbering = parseNumbering(numberingXml);
+  const bodyXml = documentXml.match(/<w:body\b[^>]*>([\s\S]*?)<\/w:body>/)?.[1] ?? documentXml;
+  const blocks = [...bodyXml.matchAll(/<(w:p|w:tbl)\b[\s\S]*?<\/\1>/g)];
+  const out: string[] = [];
+
+  for (const block of blocks) {
+    if (block[1] === 'w:tbl') {
+      const table = renderTable(block[0]);
+      if (table) out.push(table);
+      continue;
+    }
+
+    const text = paragraphText(block[0]);
+    if (!text) {
+      continue;
+    }
+    const style = paragraphStyle(block[0]);
+    const listInfo = paragraphListInfo(block[0]);
+    if (style && /^Heading[1-6]$/i.test(style)) {
+      out.push(`${'#'.repeat(Number.parseInt(style.replace(/^\D+/g, ''), 10))} ${text}`);
+      continue;
+    }
+    if (style === 'Title') {
+      out.push(`# ${text}`);
+      continue;
+    }
+    if (listInfo) {
+      const marker = numbering.get(`${listInfo.numId}:${listInfo.level}`)?.format === 'decimal' ? '1.' : '-';
+      out.push(`${'  '.repeat(listInfo.level)}${marker} ${text}`);
+      continue;
+    }
+    out.push(text);
+  }
+
+  return normalizeWhitespace(out.join('\n\n'));
+}

--- a/packages/cli/src/context/ingest/adapters/sharepoint/fetch.ts
+++ b/packages/cli/src/context/ingest/adapters/sharepoint/fetch.ts
@@ -1,0 +1,105 @@
+import { createHash } from 'node:crypto';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname, extname, join } from 'node:path';
+import { SharepointGraphClient } from './graph-client.js';
+import { normalizeSharepointFileToMarkdown } from './normalize.js';
+import {
+  SHAREPOINT_ALLOWED_EXTENSIONS,
+  SHAREPOINT_SOURCE_KEY,
+  type SharepointManifest,
+  type SharepointPullConfig,
+} from './types.js';
+
+async function writeJson(path: string, value: unknown): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, `${JSON.stringify(value, null, 2)}\n`, 'utf-8');
+}
+
+async function writeText(path: string, value: string): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, value.endsWith('\n') ? value : `${value}\n`, 'utf-8');
+}
+
+function slugifySegment(value: string): string {
+  const normalized = value
+    .normalize('NFKD')
+    .replace(/[^\x00-\x7F]/g, '')
+    .replace(/[^a-zA-Z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .toLowerCase();
+  return normalized || 'untitled';
+}
+
+function compactSegment(value: string, maxLength = 24): string {
+  const slug = slugifySegment(value);
+  return slug.length > maxLength ? slug.slice(0, maxLength).replace(/-+$/g, '') || 'untitled' : slug;
+}
+
+function shortHash(value: string, length = 10): string {
+  return createHash('sha1').update(value).digest('hex').slice(0, length);
+}
+
+function sharepointDocDirName(title: string, itemId: string): string {
+  return `${compactSegment(title)}-${shortHash(itemId)}`;
+}
+
+export async function fetchSharepointSnapshot(params: {
+  client: SharepointGraphClient;
+  config: SharepointPullConfig;
+  stagedDir: string;
+}): Promise<SharepointManifest> {
+  await mkdir(params.stagedDir, { recursive: true });
+  const listed = await params.client.listDriveFiles({
+    driveId: params.config.driveId,
+    folderId: params.config.folderId,
+    recursive: params.config.recursive,
+  });
+  const skipped: Array<{ externalId: string; reason: string }> = [];
+  let fileCount = 0;
+
+  for (const { item, drivePath } of listed) {
+    const extension = extname(item.name).toLowerCase();
+    if (!SHAREPOINT_ALLOWED_EXTENSIONS.has(extension)) {
+      skipped.push({ externalId: item.id, reason: `unsupported file extension: ${extension || '(none)'}` });
+      continue;
+    }
+    const title = item.name.replace(/\.[^.]+$/, '').trim() || item.name.trim();
+    const content = await params.client.downloadFile(params.config.driveId, item);
+    const markdown = normalizeSharepointFileToMarkdown(
+      item.name,
+      extension === '.md' ? content.toString('utf-8') : content,
+      title,
+    );
+    const relDir = join('docs', ...drivePath.map((segment) => compactSegment(segment)), sharepointDocDirName(title, item.id));
+    await writeJson(join(params.stagedDir, relDir, 'metadata.json'), {
+      id: item.id,
+      title,
+      path: [...drivePath, title].join(' / ') || title,
+      url: item.webUrl,
+      mimeType: extension === '.md' ? 'text/markdown' : 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      driveId: params.config.driveId,
+      folderId: params.config.folderId,
+      drivePath,
+      fileName: item.name,
+      lastModifiedDateTime: item.lastModifiedDateTime,
+    });
+    await writeText(join(params.stagedDir, relDir, 'page.md'), markdown);
+    fileCount += 1;
+  }
+
+  const manifest: SharepointManifest = {
+    source: SHAREPOINT_SOURCE_KEY,
+    driveId: params.config.driveId,
+    folderId: params.config.folderId,
+    recursive: params.config.recursive,
+    fetchedAt: new Date().toISOString(),
+    fileCount,
+    skipped,
+    warnings:
+      skipped.length > 0
+        ? [`Skipped ${skipped.length} unsupported SharePoint / OneDrive file(s); only Markdown and Word documents are ingested in v1.`]
+        : [],
+  };
+  await writeJson(join(params.stagedDir, 'manifest.json'), manifest);
+  return manifest;
+}

--- a/packages/cli/src/context/ingest/adapters/sharepoint/graph-client.ts
+++ b/packages/cli/src/context/ingest/adapters/sharepoint/graph-client.ts
@@ -1,0 +1,188 @@
+import { SHAREPOINT_GRAPH_SCOPE, type SharepointDiscoveredDrive, type SharepointDriveItem } from './types.js';
+
+interface GraphClientOptions {
+  tenantId: string;
+  clientId: string;
+  clientSecret: string;
+  fetchImpl?: typeof fetch;
+}
+
+interface ListDriveFilesOptions {
+  driveId: string;
+  folderId: string;
+  recursive: boolean;
+}
+
+export interface ListedDriveFile {
+  item: SharepointDriveItem;
+  drivePath: string[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function parseDriveItem(value: unknown): SharepointDriveItem {
+  if (!isRecord(value) || typeof value.id !== 'string' || typeof value.name !== 'string') {
+    throw new Error('Microsoft Graph returned an invalid drive item payload');
+  }
+  const file = isRecord(value.file) ? { mimeType: typeof value.file.mimeType === 'string' ? value.file.mimeType : null } : null;
+  const folder = isRecord(value.folder)
+    ? { childCount: typeof value.folder.childCount === 'number' ? value.folder.childCount : null }
+    : null;
+  return {
+    id: value.id,
+    name: value.name,
+    webUrl: typeof value.webUrl === 'string' ? value.webUrl : null,
+    lastModifiedDateTime: typeof value.lastModifiedDateTime === 'string' ? value.lastModifiedDateTime : null,
+    file,
+    folder,
+    downloadUrl: typeof value['@microsoft.graph.downloadUrl'] === 'string' ? value['@microsoft.graph.downloadUrl'] : null,
+  };
+}
+
+export class SharepointGraphClient {
+  private readonly fetchImpl: typeof fetch;
+  private accessToken: string | null = null;
+
+  constructor(private readonly options: GraphClientOptions) {
+    this.fetchImpl = options.fetchImpl ?? fetch;
+  }
+
+  private async ensureAccessToken(): Promise<string> {
+    if (this.accessToken) {
+      return this.accessToken;
+    }
+    const response = await this.fetchImpl(
+      `https://login.microsoftonline.com/${this.options.tenantId}/oauth2/v2.0/token`,
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({
+          grant_type: 'client_credentials',
+          client_id: this.options.clientId,
+          client_secret: this.options.clientSecret,
+          scope: SHAREPOINT_GRAPH_SCOPE,
+        }),
+      },
+    );
+    if (!response.ok) {
+      throw new Error(`Microsoft Graph token request failed (${response.status} ${response.statusText})`);
+    }
+    const payload = (await response.json()) as { access_token?: unknown };
+    if (typeof payload.access_token !== 'string' || payload.access_token.length === 0) {
+      throw new Error('Microsoft Graph token response did not include access_token');
+    }
+    this.accessToken = payload.access_token;
+    return this.accessToken;
+  }
+
+  private async graphJson<T>(url: string): Promise<T> {
+    const token = await this.ensureAccessToken();
+    const response = await this.fetchImpl(url, {
+      headers: {
+        authorization: `Bearer ${token}`,
+        accept: 'application/json',
+      },
+    });
+    if (!response.ok) {
+      throw new Error(`Microsoft Graph request failed (${response.status} ${response.statusText}) for ${url}`);
+    }
+    return (await response.json()) as T;
+  }
+
+  private async listChildrenPage(url: string): Promise<{ items: SharepointDriveItem[]; nextLink: string | null }> {
+    const payload = await this.graphJson<{ value?: unknown[]; '@odata.nextLink'?: unknown }>(url);
+    return {
+      items: Array.isArray(payload.value) ? payload.value.map(parseDriveItem) : [],
+      nextLink: typeof payload['@odata.nextLink'] === 'string' ? payload['@odata.nextLink'] : null,
+    };
+  }
+
+  async listDriveFiles(options: ListDriveFilesOptions): Promise<ListedDriveFile[]> {
+    const listed: ListedDriveFile[] = [];
+    await this.walkFolder(
+      options.driveId,
+      `https://graph.microsoft.com/v1.0/drives/${encodeURIComponent(options.driveId)}/items/${encodeURIComponent(options.folderId)}/children?$top=200`,
+      options.recursive,
+      [],
+      listed,
+    );
+    return listed;
+  }
+
+  private async walkFolder(
+    driveId: string,
+    url: string,
+    recursive: boolean,
+    parents: string[],
+    out: ListedDriveFile[],
+  ): Promise<void> {
+    let nextLink: string | null = url;
+    while (nextLink) {
+      const page = await this.listChildrenPage(nextLink);
+      for (const item of page.items) {
+        if (item.folder) {
+          if (recursive) {
+            await this.walkFolder(
+              driveId,
+              `https://graph.microsoft.com/v1.0/drives/${encodeURIComponent(driveId)}/items/${encodeURIComponent(item.id)}/children?$top=200`,
+              true,
+              [...parents, item.name],
+              out,
+            );
+          }
+          continue;
+        }
+        out.push({ item, drivePath: parents });
+      }
+      nextLink = page.nextLink;
+    }
+  }
+
+  async getDriveItem(driveId: string, itemId: string): Promise<SharepointDriveItem> {
+    return parseDriveItem(
+      await this.graphJson(`https://graph.microsoft.com/v1.0/drives/${encodeURIComponent(driveId)}/items/${encodeURIComponent(itemId)}`),
+    );
+  }
+
+  async downloadFile(driveId: string, item: SharepointDriveItem): Promise<Buffer> {
+    const token = await this.ensureAccessToken();
+    const response = await this.fetchImpl(
+      item.downloadUrl ?? `https://graph.microsoft.com/v1.0/drives/${encodeURIComponent(driveId)}/items/${encodeURIComponent(item.id)}/content`,
+      {
+        headers: item.downloadUrl ? undefined : { authorization: `Bearer ${token}` },
+      },
+    );
+    if (!response.ok) {
+      throw new Error(`Microsoft Graph download failed (${response.status} ${response.statusText}) for ${item.name}`);
+    }
+    return Buffer.from(await response.arrayBuffer());
+  }
+
+  async listDrivesForSite(siteId: string): Promise<SharepointDiscoveredDrive[]> {
+    const drives: SharepointDiscoveredDrive[] = [];
+    let nextLink: string | null = `https://graph.microsoft.com/v1.0/sites/${encodeURIComponent(siteId)}/drives?$top=200`;
+    while (nextLink) {
+      const payload: { value?: unknown[]; '@odata.nextLink'?: unknown } = await this.graphJson(nextLink);
+      if (Array.isArray(payload.value)) {
+        for (const candidate of payload.value) {
+          if (!isRecord(candidate) || typeof candidate.id !== 'string' || typeof candidate.name !== 'string') {
+            continue;
+          }
+          drives.push({
+            id: candidate.id,
+            name: candidate.name,
+            webUrl: typeof candidate.webUrl === 'string' ? candidate.webUrl : null,
+          });
+        }
+      }
+      nextLink = typeof payload['@odata.nextLink'] === 'string' ? payload['@odata.nextLink'] : null;
+    }
+    return drives;
+  }
+}
+
+export function createSharepointGraphClient(options: GraphClientOptions): SharepointGraphClient {
+  return new SharepointGraphClient(options);
+}

--- a/packages/cli/src/context/ingest/adapters/sharepoint/normalize.ts
+++ b/packages/cli/src/context/ingest/adapters/sharepoint/normalize.ts
@@ -1,0 +1,19 @@
+import { extname } from 'node:path';
+import { convertDocxToMarkdown } from './docx-markdown.js';
+
+function normalizeMarkdownText(value: string): string {
+  const normalized = value.replace(/\r\n/g, '\n').replace(/\r/g, '\n').trimEnd();
+  return normalized.length > 0 ? `${normalized}\n` : '';
+}
+
+export function normalizeSharepointFileToMarkdown(fileName: string, content: Buffer | string, title: string): string {
+  const extension = extname(fileName).toLowerCase();
+  if (extension === '.md') {
+    return normalizeMarkdownText(typeof content === 'string' ? content : content.toString('utf-8'));
+  }
+  const converted = convertDocxToMarkdown(Buffer.isBuffer(content) ? content : Buffer.from(content, 'utf-8')).trim();
+  if (!converted) {
+    return `# ${title}\n`;
+  }
+  return /^#\s+/m.test(converted) ? `${converted}\n` : `# ${title}\n\n${converted}\n`;
+}

--- a/packages/cli/src/context/ingest/adapters/sharepoint/sharepoint.adapter.ts
+++ b/packages/cli/src/context/ingest/adapters/sharepoint/sharepoint.adapter.ts
@@ -1,0 +1,34 @@
+import type { ChunkResult, DiffSet, FetchContext, ScopeDescriptor, SourceAdapter } from '../../types.js';
+import { chunkSharepointStagedDir, describeSharepointScope } from './chunk.js';
+import { detectSharepointStagedDir } from './detect.js';
+import { fetchSharepointSnapshot } from './fetch.js';
+import { createSharepointGraphClient } from './graph-client.js';
+import { sharepointPullConfigSchema } from './types.js';
+
+export class SharepointSourceAdapter implements SourceAdapter {
+  readonly source = 'sharepoint';
+  readonly skillNames = ['sharepoint_synthesize'];
+  readonly reconcileSkillNames: string[] = [];
+  readonly evidenceIndexing = 'documents' as const;
+
+  detect(stagedDir: string): Promise<boolean> {
+    return detectSharepointStagedDir(stagedDir);
+  }
+
+  async fetch(pullConfig: unknown, stagedDir: string, _ctx: FetchContext): Promise<void> {
+    const config = sharepointPullConfigSchema.parse(pullConfig);
+    await fetchSharepointSnapshot({
+      client: createSharepointGraphClient(config),
+      config,
+      stagedDir,
+    });
+  }
+
+  chunk(stagedDir: string, diffSet?: DiffSet): Promise<ChunkResult> {
+    return chunkSharepointStagedDir(stagedDir, diffSet);
+  }
+
+  describeScope(stagedDir: string): Promise<ScopeDescriptor> {
+    return describeSharepointScope(stagedDir);
+  }
+}

--- a/packages/cli/src/context/ingest/adapters/sharepoint/types.ts
+++ b/packages/cli/src/context/ingest/adapters/sharepoint/types.ts
@@ -1,0 +1,55 @@
+import { z } from 'zod';
+
+export const SHAREPOINT_SOURCE_KEY = 'sharepoint';
+export const SHAREPOINT_ALLOWED_EXTENSIONS = new Set(['.docx', '.md']);
+export const SHAREPOINT_GRAPH_SCOPE = 'https://graph.microsoft.com/.default';
+
+export const sharepointPullConfigSchema = z.object({
+  tenantId: z.string().min(1),
+  clientId: z.string().min(1),
+  clientSecret: z.string().min(1),
+  driveId: z.string().min(1),
+  folderId: z.string().min(1),
+  recursive: z.boolean().default(false),
+});
+export type SharepointPullConfig = z.infer<typeof sharepointPullConfigSchema>;
+
+export const sharepointManifestSchema = z.object({
+  source: z.literal(SHAREPOINT_SOURCE_KEY),
+  driveId: z.string().min(1),
+  folderId: z.string().min(1),
+  recursive: z.boolean(),
+  fetchedAt: z.string().datetime(),
+  fileCount: z.number().int().nonnegative(),
+  skipped: z.array(z.object({ externalId: z.string(), reason: z.string() })).default([]),
+  warnings: z.array(z.string()).default([]),
+});
+export type SharepointManifest = z.infer<typeof sharepointManifestSchema>;
+
+export const sharepointMetadataSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  path: z.string(),
+  url: z.string().nullable().default(null),
+  mimeType: z.enum(['text/markdown', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document']),
+  driveId: z.string(),
+  folderId: z.string(),
+  drivePath: z.array(z.string()).default([]),
+  fileName: z.string(),
+  lastModifiedDateTime: z.string().datetime().nullable().default(null),
+});
+export interface SharepointDriveItem {
+  id: string;
+  name: string;
+  webUrl: string | null;
+  lastModifiedDateTime: string | null;
+  file: { mimeType?: string | null } | null;
+  folder: { childCount?: number | null } | null;
+  downloadUrl: string | null;
+}
+
+export interface SharepointDiscoveredDrive {
+  id: string;
+  name: string;
+  webUrl: string | null;
+}

--- a/packages/cli/src/context/ingest/local-adapters.ts
+++ b/packages/cli/src/context/ingest/local-adapters.ts
@@ -1,5 +1,6 @@
 import { join } from 'node:path';
 import { gdriveConnectionToPullConfig, parseGdriveConnectionConfig } from '../../context/connections/gdrive-config.js';
+import { parseSharepointConnectionConfig, sharepointConnectionToPullConfig } from '../../context/connections/sharepoint-config.js';
 import { localConnectionToWarehouseDescriptor } from '../../context/connections/local-warehouse-descriptor.js';
 import { notionConnectionToPullConfig, parseNotionConnectionConfig } from '../../context/connections/notion-config.js';
 import { resolveKtxConfigReference } from '../core/config-reference.js';
@@ -9,6 +10,7 @@ import type { SqlAnalysisPort } from '../../context/sql-analysis/ports.js';
 import { DbtSourceAdapter } from './adapters/dbt/dbt.adapter.js';
 import { FakeSourceAdapter } from './adapters/fake/fake.adapter.js';
 import { GdriveSourceAdapter } from './adapters/gdrive/gdrive.adapter.js';
+import { SharepointSourceAdapter } from './adapters/sharepoint/sharepoint.adapter.js';
 import { HistoricSqlSourceAdapter } from './adapters/historic-sql/historic-sql.adapter.js';
 import { PostgresPgssReader } from './adapters/historic-sql/postgres-pgss-reader.js';
 import { resolveQueryHistoryScopeFloor } from './adapters/historic-sql/scope-floor.js';
@@ -112,6 +114,7 @@ export function createDefaultLocalIngestAdapters(
       ...(options.logger ? { logger: options.logger } : {}),
     }),
     new GdriveSourceAdapter(),
+    new SharepointSourceAdapter(),
     new LookerSourceAdapter({
       clientFactory: {
         async createClient(config, ctx) {
@@ -362,6 +365,9 @@ export async function localPullConfigForAdapter(
   }
   if (adapter.source === 'gdrive') {
     return await gdriveConnectionToPullConfig(parseGdriveConnectionConfig(connection));
+  }
+  if (adapter.source === 'sharepoint') {
+    return await sharepointConnectionToPullConfig(parseSharepointConnectionConfig(connection));
   }
   if (adapter.source === 'metricflow') {
     const metricflow = connection.metricflow;

--- a/packages/cli/src/context/project/driver-schemas.ts
+++ b/packages/cli/src/context/project/driver-schemas.ts
@@ -233,6 +233,26 @@ const gdriveConnectionSchema = z
   })
   .describe('Google Drive Google Docs context-source connection.');
 
+const sharepointConnectionSchema = z
+  .looseObject({
+    driver: z.literal('sharepoint'),
+    tenant_id_ref: z
+      .string()
+      .min(1)
+      .describe('Environment-variable reference for the Azure tenant id. Must use env:AZURE_TENANT_ID.'),
+    client_id_ref: z
+      .string()
+      .min(1)
+      .describe('Environment-variable reference for the Azure client id. Must use env:AZURE_CLIENT_ID.'),
+    client_secret_ref: z
+      .string()
+      .min(1)
+      .describe('Environment-variable reference for the Azure client secret. Must use env:AZURE_CLIENT_SECRET.'),
+    drive_id: z.string().min(1).describe('Microsoft Graph drive id for the SharePoint document library or OneDrive drive.'),
+    folder_id: z.string().min(1).describe('Drive item id for the root folder to ingest within the selected drive.'),
+    recursive: z.boolean().optional().describe('When true, recursively traverse subfolders beneath folder_id.'),
+  })
+  .describe('SharePoint / OneDrive context-source connection.');
 const dbtConnectionSchema = z
   .looseObject({
     driver: z.literal('dbt'),
@@ -310,6 +330,7 @@ export const connectionConfigSchema = z.discriminatedUnion('driver', [
   lookmlConnectionSchema,
   notionConnectionSchema,
   gdriveConnectionSchema,
+  sharepointConnectionSchema,
   dbtConnectionSchema,
   metricflowConnectionSchema,
   sigmaConnectionSchema,

--- a/packages/cli/src/ingest.ts
+++ b/packages/cli/src/ingest.ts
@@ -121,6 +121,7 @@ const REPORT_SOURCE_LABELS = new Map<string, string>([
   ['looker', 'Looker'],
   ['metabase', 'Metabase'],
   ['notion', 'Notion'],
+  ['sharepoint', 'SharePoint / OneDrive'],
 ]);
 
 function reportSourceLabel(sourceKey: string): string {

--- a/packages/cli/src/public-ingest.ts
+++ b/packages/cli/src/public-ingest.ts
@@ -136,6 +136,7 @@ const sourceAdapterByDriver = new Map<string, string>([
   ['looker', 'looker'],
   ['notion', 'notion'],
   ['gdrive', 'gdrive'],
+  ['sharepoint', 'sharepoint'],
   ['metricflow', 'metricflow'],
   ['dbt', 'dbt'],
   ['lookml', 'lookml'],

--- a/packages/cli/src/setup-sources.ts
+++ b/packages/cli/src/setup-sources.ts
@@ -1,6 +1,6 @@
 import { mkdtemp, readdir, readFile, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join, relative, resolve } from 'node:path';
+import { extname, join, relative, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { localConnectionTypeForConfig } from './context/connections/local-warehouse-descriptor.js';
 import {
@@ -8,12 +8,15 @@ import {
   resolveGdriveServiceAccountKey,
 } from './context/connections/gdrive-config.js';
 import { resolveNotionConnectionAuthToken } from './context/connections/notion-config.js';
+import { parseSharepointConnectionConfig, sharepointConnectionToPullConfig } from './context/connections/sharepoint-config.js';
 import { resolveKtxConfigReference } from './context/core/config-reference.js';
 import {
   createGoogleDocsClients,
   verifyGdriveFolderAndCountDocs,
 } from './context/ingest/adapters/gdrive/gdrive-client.js';
 import { gdriveServiceAccountKeySchema } from './context/ingest/adapters/gdrive/types.js';
+import { createSharepointGraphClient } from './context/ingest/adapters/sharepoint/graph-client.js';
+import { SHAREPOINT_ALLOWED_EXTENSIONS } from './context/ingest/adapters/sharepoint/types.js';
 import { cloneOrPull, testRepoConnection } from './context/ingest/repo-fetch.js';
 import { DEFAULT_METABASE_CLIENT_CONFIG, MetabaseClient } from './context/ingest/adapters/metabase/client.js';
 import { DEFAULT_SIGMA_CLIENT_CONFIG, DefaultSigmaClient } from './context/ingest/adapters/sigma/client.js';
@@ -48,7 +51,7 @@ import {
   type KtxSetupPromptOption,
 } from './setup-prompts.js';
 
-export type KtxSetupSourceType = 'dbt' | 'metricflow' | 'metabase' | 'looker' | 'lookml' | 'notion' | 'sigma' | 'gdrive';
+export type KtxSetupSourceType = 'dbt' | 'metricflow' | 'metabase' | 'looker' | 'lookml' | 'notion' | 'sigma' | 'gdrive' | 'sharepoint';
 
 const DEFAULT_NOTION_MAX_KNOWLEDGE_CREATES_PER_RUN = 25;
 
@@ -76,6 +79,13 @@ export interface KtxSetupSourcesArgs {
   gdriveServiceAccountKeyRef?: string;
   gdriveFolderId?: string;
   gdriveRecursive?: boolean;
+  sharepointTenantIdRef?: string;
+  sharepointClientIdRef?: string;
+  sharepointClientSecretRef?: string;
+  sharepointDriveId?: string;
+  sharepointFolderId?: string;
+  sharepointRecursive?: boolean;
+  sharepointSiteId?: string;
   runInitialSourceIngest: boolean;
   skipSources: boolean;
 }
@@ -119,6 +129,7 @@ export interface KtxSetupSourcesDeps {
   validateNotion?: (connection: KtxProjectConnectionConfig) => Promise<SourceValidationResult>;
   validateSigma?: (connection: KtxProjectConnectionConfig) => Promise<SourceValidationResult>;
   validateGdrive?: (connection: KtxProjectConnectionConfig) => Promise<SourceValidationResult>;
+  validateSharepoint?: (connection: KtxProjectConnectionConfig) => Promise<SourceValidationResult>;
   pickNotionRootPages?: typeof pickNotionRootPages;
   discoverMetabaseDatabases?: (args: {
     sourceUrl: string;
@@ -143,6 +154,7 @@ const SOURCE_OPTIONS: Array<{ value: KtxSetupSourceType; label: string }> = [
   { value: 'lookml', label: 'LookML' },
   { value: 'sigma', label: 'Sigma Computing' },
   { value: 'gdrive', label: 'Google Drive' },
+  { value: 'sharepoint', label: 'SharePoint / OneDrive' },
 ];
 
 const SOURCE_LABELS = Object.fromEntries(SOURCE_OPTIONS.map((option) => [option.value, option.label])) as Record<
@@ -254,6 +266,7 @@ const SOURCE_CREDENTIAL_FLAG: Record<KtxSetupSourceType, SourceCredentialFlag> =
   looker: { field: 'sourceClientSecretRef', flag: '--source-client-secret-ref' },
   sigma: { field: 'sourceClientSecretRef', flag: '--source-client-secret-ref' },
   gdrive: { field: null, flag: '--gdrive-service-account-key-ref' },
+  sharepoint: { field: null, flag: '--sharepoint-tenant-id-ref' },
 };
 
 const ALL_SOURCE_CREDENTIAL_FLAGS: Array<{ field: SharedSourceCredentialField; flag: string }> = [
@@ -610,6 +623,26 @@ function buildGdriveConnection(args: KtxSetupSourcesArgs): KtxProjectConnectionC
   };
 }
 
+function buildSharepointConnection(args: KtxSetupSourcesArgs): KtxProjectConnectionConfig {
+  const driveId = args.sharepointDriveId?.trim();
+  const folderId = args.sharepointFolderId?.trim();
+  if (!driveId) {
+    throw new Error('SharePoint setup requires --sharepoint-drive-id.');
+  }
+  if (!folderId) {
+    throw new Error('SharePoint setup requires --sharepoint-folder-id.');
+  }
+  return {
+    driver: 'sharepoint',
+    tenant_id_ref: credentialRef(args.sharepointTenantIdRef, 'SharePoint tenant id ref'),
+    client_id_ref: credentialRef(args.sharepointClientIdRef, 'SharePoint client id ref'),
+    client_secret_ref: credentialRef(args.sharepointClientSecretRef, 'SharePoint client secret ref'),
+    drive_id: driveId,
+    folder_id: folderId,
+    recursive: args.sharepointRecursive === true,
+  };
+}
+
 function sourcePathFromFileRepoUrl(repoUrl: string, subpath?: string): string {
   const root = fileURLToPath(repoUrl);
   return subpath ? join(root, subpath) : root;
@@ -752,6 +785,20 @@ async function defaultValidateGdrive(connection: KtxProjectConnectionConfig): Pr
   const keyText = await resolveGdriveServiceAccountKey(config.service_account_key_ref);
   const clients = createGoogleDocsClients(gdriveServiceAccountKeySchema.parse(JSON.parse(keyText)));
   const docs = await verifyGdriveFolderAndCountDocs(clients.drive, config.folder_id);
+  return { ok: true, detail: `docs=${docs}` };
+}
+
+async function defaultValidateSharepoint(connection: KtxProjectConnectionConfig): Promise<SourceValidationResult> {
+  const config = parseSharepointConnectionConfig(connection);
+  const pullConfig = await sharepointConnectionToPullConfig(config);
+  const client = createSharepointGraphClient(pullConfig);
+  const folder = await client.getDriveItem(config.drive_id, config.folder_id);
+  if (!folder.folder) {
+    return { ok: false, message: `SharePoint folder ${config.folder_id} is not accessible` };
+  }
+  const docs = (await client.listDriveFiles({ driveId: config.drive_id, folderId: config.folder_id, recursive: config.recursive }))
+    .filter(({ item }) => SHAREPOINT_ALLOWED_EXTENSIONS.has(extname(item.name).toLowerCase()))
+    .length;
   return { ok: true, detail: `docs=${docs}` };
 }
 
@@ -1506,6 +1553,107 @@ async function promptForInteractiveSource(
     ]);
   }
 
+  if (source === 'sharepoint') {
+    return await runSourcePromptSteps(initialState, () => [
+      ...connectionSteps,
+      async (currentState) => {
+        const tenantIdRef = await promptText(prompts, {
+          message: 'Azure tenant id reference',
+          placeholder: 'env:AZURE_TENANT_ID',
+          ...(currentState.sharepointTenantIdRef ? { initialValue: currentState.sharepointTenantIdRef } : {}),
+        });
+        if (tenantIdRef === undefined) return 'back';
+        currentState.sharepointTenantIdRef = tenantIdRef.trim();
+        return 'next';
+      },
+      async (currentState) => {
+        const clientIdRef = await promptText(prompts, {
+          message: 'Azure client id reference',
+          placeholder: 'env:AZURE_CLIENT_ID',
+          ...(currentState.sharepointClientIdRef ? { initialValue: currentState.sharepointClientIdRef } : {}),
+        });
+        if (clientIdRef === undefined) return 'back';
+        currentState.sharepointClientIdRef = clientIdRef.trim();
+        return 'next';
+      },
+      async (currentState) => {
+        const clientSecretRef = await promptText(prompts, {
+          message: 'Azure client secret reference',
+          placeholder: 'env:AZURE_CLIENT_SECRET',
+          ...(currentState.sharepointClientSecretRef ? { initialValue: currentState.sharepointClientSecretRef } : {}),
+        });
+        if (clientSecretRef === undefined) return 'back';
+        currentState.sharepointClientSecretRef = clientSecretRef.trim();
+        return 'next';
+      },
+      async (currentState) => {
+        const siteId = await promptText(prompts, {
+          message: 'Microsoft Graph site id (optional drive discovery helper)',
+          ...(currentState.sharepointSiteId ? { initialValue: currentState.sharepointSiteId } : {}),
+        });
+        if (siteId === undefined) return 'back';
+        currentState.sharepointSiteId = siteId.trim() || undefined;
+        if (currentState.sharepointSiteId) {
+          try {
+            const pullConfig = await sharepointConnectionToPullConfig({
+              driver: 'sharepoint',
+              tenant_id_ref: credentialRef(currentState.sharepointTenantIdRef, 'SharePoint tenant id ref'),
+              client_id_ref: credentialRef(currentState.sharepointClientIdRef, 'SharePoint client id ref'),
+              client_secret_ref: credentialRef(currentState.sharepointClientSecretRef, 'SharePoint client secret ref'),
+              drive_id: currentState.sharepointDriveId ?? 'setup-drive-placeholder',
+              folder_id: currentState.sharepointFolderId ?? 'setup-folder-placeholder',
+              recursive: currentState.sharepointRecursive === true,
+            });
+            const drives = await createSharepointGraphClient(pullConfig).listDrivesForSite(currentState.sharepointSiteId);
+            if (drives.length === 1 && !currentState.sharepointDriveId) {
+              currentState.sharepointDriveId = drives[0].id;
+              prompts.log?.(`Found drive ${drives[0].name} (${drives[0].id})`);
+            } else if (drives.length > 1) {
+              prompts.log?.('Discovered drives:');
+              for (const drive of drives) {
+                prompts.log?.(`- ${drive.name}: ${drive.id}`);
+              }
+            }
+          } catch (error) {
+            prompts.log?.(`Drive discovery unavailable: ${error instanceof Error ? error.message : String(error)}`);
+          }
+        }
+        return 'next';
+      },
+      async (currentState) => {
+        const driveId = await promptText(prompts, {
+          message: 'Microsoft Graph drive id',
+          ...(currentState.sharepointDriveId ? { initialValue: currentState.sharepointDriveId } : {}),
+        });
+        if (driveId === undefined) return 'back';
+        currentState.sharepointDriveId = driveId.trim();
+        return 'next';
+      },
+      async (currentState) => {
+        const folderId = await promptText(prompts, {
+          message: 'Microsoft Graph folder item id',
+          ...(currentState.sharepointFolderId ? { initialValue: currentState.sharepointFolderId } : {}),
+        });
+        if (folderId === undefined) return 'back';
+        currentState.sharepointFolderId = folderId.trim();
+        return 'next';
+      },
+      async (currentState) => {
+        const recursive = await prompts.select({
+          message: 'Include SharePoint / OneDrive docs from subfolders?',
+          options: [
+            { value: 'false', label: 'No' },
+            { value: 'true', label: 'Yes' },
+            { value: 'back', label: 'Back' },
+          ],
+        });
+        if (recursive === 'back') return 'back';
+        currentState.sharepointRecursive = recursive === 'true';
+        return 'next';
+      },
+    ]);
+  }
+
   return await runSourcePromptSteps(initialState, () => [
     ...connectionSteps,
     async (currentState) => {
@@ -1723,6 +1871,16 @@ function sourceArgsFromExistingConnection(input: {
     return sourceArgs;
   }
 
+  if (input.source === 'sharepoint') {
+    sourceArgs.sharepointTenantIdRef = stringField(input.connection.tenant_id_ref);
+    sourceArgs.sharepointClientIdRef = stringField(input.connection.client_id_ref);
+    sourceArgs.sharepointClientSecretRef = stringField(input.connection.client_secret_ref);
+    sourceArgs.sharepointDriveId = stringField(input.connection.drive_id);
+    sourceArgs.sharepointFolderId = stringField(input.connection.folder_id);
+    sourceArgs.sharepointRecursive = input.connection.recursive === true;
+    return sourceArgs;
+  }
+
   sourceArgs.sourceAuthTokenRef = stringField(input.connection.auth_token_ref);
   sourceArgs.notionCrawlMode =
     input.connection.crawl_mode === 'all_accessible' ? 'all_accessible' : 'selected_roots';
@@ -1910,6 +2068,9 @@ function buildConnection(source: KtxSetupSourceType, args: KtxSetupSourcesArgs):
   if (source === 'notion') {
     return buildNotionConnection(args);
   }
+  if (source === 'sharepoint') {
+    return buildSharepointConnection(args);
+  }
   return buildGdriveConnection(args);
 }
 
@@ -1940,6 +2101,9 @@ async function validateSource(
   }
   if (source === 'notion') {
     return await (deps.validateNotion ?? defaultValidateNotion)(args.connection);
+  }
+  if (source === 'sharepoint') {
+    return await (deps.validateSharepoint ?? defaultValidateSharepoint)(args.connection);
   }
   return await (deps.validateGdrive ?? defaultValidateGdrive)(args.connection);
 }

--- a/packages/cli/src/setup.ts
+++ b/packages/cli/src/setup.ts
@@ -129,6 +129,13 @@ export type KtxSetupArgs =
       gdriveServiceAccountKeyRef?: string;
       gdriveFolderId?: string;
       gdriveRecursive?: boolean;
+      sharepointTenantIdRef?: string;
+      sharepointClientIdRef?: string;
+      sharepointClientSecretRef?: string;
+      sharepointDriveId?: string;
+      sharepointFolderId?: string;
+      sharepointRecursive?: boolean;
+      sharepointSiteId?: string;
       runInitialSourceIngest?: boolean;
       skipSources?: boolean;
       showEntryMenu?: boolean;
@@ -170,7 +177,7 @@ export interface KtxSetupDeps {
   setupUi?: KtxSetupUiAdapter;
 }
 
-const SOURCE_DRIVERS = new Set(['dbt', 'metricflow', 'metabase', 'looker', 'lookml', 'notion', 'gdrive']);
+const SOURCE_DRIVERS = new Set(['dbt', 'metricflow', 'metabase', 'looker', 'lookml', 'notion', 'gdrive', 'sharepoint']);
 const KTX_DOCS_URL = 'https://docs.kaelio.com/ktx';
 
 type KtxSetupEntryAction = 'setup' | 'new-project' | 'agents' | 'status' | 'demo' | 'exit';
@@ -881,6 +888,13 @@ async function runKtxSetupInner(args: KtxSetupArgs, io: KtxCliIo, deps: KtxSetup
               : {}),
             ...(args.gdriveFolderId ? { gdriveFolderId: args.gdriveFolderId } : {}),
             ...(args.gdriveRecursive !== undefined ? { gdriveRecursive: args.gdriveRecursive } : {}),
+            ...(args.sharepointTenantIdRef ? { sharepointTenantIdRef: args.sharepointTenantIdRef } : {}),
+            ...(args.sharepointClientIdRef ? { sharepointClientIdRef: args.sharepointClientIdRef } : {}),
+            ...(args.sharepointClientSecretRef ? { sharepointClientSecretRef: args.sharepointClientSecretRef } : {}),
+            ...(args.sharepointDriveId ? { sharepointDriveId: args.sharepointDriveId } : {}),
+            ...(args.sharepointFolderId ? { sharepointFolderId: args.sharepointFolderId } : {}),
+            ...(args.sharepointRecursive !== undefined ? { sharepointRecursive: args.sharepointRecursive } : {}),
+            ...(args.sharepointSiteId ? { sharepointSiteId: args.sharepointSiteId } : {}),
             runInitialSourceIngest: args.runInitialSourceIngest ?? false,
             skipSources: args.skipSources === true || !shouldRunSources || skipSourcesFromDatabaseMenu,
           },

--- a/packages/cli/src/skills/sharepoint_synthesize/SKILL.md
+++ b/packages/cli/src/skills/sharepoint_synthesize/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: sharepoint_synthesize
+description: Synthesize durable ktx wiki pages from staged SharePoint or OneDrive document pulls. Load when a WorkUnit contains SharePoint raw files from `docs/**`.
+callers: [memory_agent]
+---
+
+# SharePoint / OneDrive Doc Synthesis
+
+Use this skill when a WorkUnit contains staged SharePoint or OneDrive content from `docs/**`.
+
+## Role
+
+Each WorkUnit is one document plus its metadata. Read the assigned raw files, then write a small set of durable wiki entries that capture reusable organizational knowledge. Write final memory directly; do not write candidates.
+
+## Required Workflow
+
+1. Read the WorkUnit notes and `rawFiles` list. Document content lives in `page.md`; `metadata.json` holds title, path, url, modified time, and folder context.
+2. For each assigned doc, call `read_raw_file`, or `read_raw_span` for oversized docs when the notes specify a span.
+3. Search `wiki_search` for existing pages that overlap the WorkUnit topics. Prefer updating an existing page over creating a duplicate.
+4. Use `context_evidence_search`, `context_evidence_read`, and `context_evidence_neighbors` when indexed document chunks would help reconcile related facts. Pass `chunkId` and `documentId` values verbatim as returned by the evidence tools.
+5. Write durable business knowledge with `wiki_write`. Aim for a small number of high-quality pages per doc. Include `rawPaths` with the exact SharePoint raw files that support each page.
+6. If a doc references warehouse, dbt, Looker, Metabase, or MetricFlow objects, you may verify them with `discover_data`, `entity_details`, `sql_execution`, `sl_discover`, or `sl_read_source`, but SharePoint docs are knowledge-only in v1. Do not create semantic-layer sources under the `sharepoint` connection.
+7. For every deleted raw path in the Eviction Set, call `eviction_list`, decide retention, then `emit_eviction_decision`. Do this even when no wiki write is needed.
+
+## What To Capture
+
+Capture durable, reusable company knowledge:
+
+- policies, workflows, process rules, ownership conventions, and operating procedures
+- product definitions, business terminology, and organizational guidance
+- source-of-truth statements, caveats, conflict notes, and supersession guidance
+- cross-system aliases that connect doc terminology to warehouse, dbt, Looker, Metabase, or MetricFlow names
+
+Skip noisy or transient content:
+
+- brainstorming notes with no durable rule
+- task lists, meeting scheduling details, and time-bounded status updates
+- duplicate docs with no new fact
+- shallow summaries that add no reusable policy or definition
+
+## Quality
+
+Prefer fewer, stronger entries. Every wiki entry must cite at least one SharePoint or OneDrive doc using its title or path and last modified date when available. When evidence conflicts, write a conflict note inside the wiki page rather than choosing silently.
+
+If one doc covers several related ideas, synthesize the shared durable rules instead of writing one thin page per paragraph. For oversized spans, read only the assigned span unless the WorkUnit explicitly asks for neighboring context.
+
+Search existing wiki pages for the same `tables:` or `sl_refs:` frontmatter and for source-of-truth aliases before creating a new page. If an existing page already documents the same warehouse object or business concept, update it instead of creating a differently named duplicate.
+
+## Citation Style
+
+```md
+## Agentic Harness
+- The harness provides the operational framework that turns an agent prototype into a production system.
+- Source: SharePoint Doc - Herness, last modified 2026-05-24.
+- Conflict note: An older internal note uses a narrower definition focused only on tool wiring; treat the current SharePoint doc as the durable operating definition unless replaced explicitly.
+```
+
+## Semantic-Layer Rules
+
+- SharePoint docs are knowledge-only in v1; keep durable output in wiki pages.
+- Do not create semantic-layer sources under the `sharepoint` connection.
+- If a doc references an existing warehouse or semantic-layer object and you can verify it, you may attach `sl_refs` in wiki output after confirmation.
+- If a doc mentions a table or source that cannot be verified, keep the identifier in wiki text as unverified or use `emit_unmapped_fallback` only when the missing physical object itself is the important durable fact.
+
+## Identifier Verification Protocol
+
+Before writing a wiki page on any topic:
+
+1. `discover_data({query: "<topic>"})` - see what wikis, SL sources, and raw
+   tables already exist. Prefer updating existing pages over creating new ones.
+
+Before emitting any `schema.table` or `schema.table.column` into a wiki body,
+`tables:` frontmatter, `sl_refs`, or `emit_unmapped_fallback`:
+
+2. `entity_details({connectionId, targets: [{display: "<identifier>"}]})` -
+   confirm the identifier resolves; inspect native types, FK/PK, and
+   sampleValues.
+3. For literal values from the doc, such as status codes or plan tiers,
+   check whether they appear in `entity_details` sampleValues for the relevant
+   column. If sampleValues is short or the sample may have missed real values,
+   run a `sql_execution` probe with the same warehouse connection id:
+   `sql_execution({connectionId, sql: "SELECT DISTINCT <col> FROM <ref> LIMIT 50"})`.
+4. If the candidate identifier still does not resolve, do one of:
+   - Use `sql_execution({connectionId, sql: "SELECT 1 FROM <ref> LIMIT 0"})`.
+     If it errors, the identifier is fictional.
+   - Wrap the identifier in `[unverified - from <rawPath>]` in the wiki body,
+     citing the exact raw path that mentioned it.
+   - When recording `emit_unmapped_fallback` with `no_physical_table`, include
+     the failing probe error in `clarification`.
+5. Never copy `<schema>.<table>` placeholder strings from these instructions
+   into output.
+
+## Tools
+
+Allowed: `read_raw_file`, `read_raw_span`, `wiki_search`, `wiki_read`, `wiki_write`, `discover_data`, `entity_details`, `sql_execution`, `sl_discover`, `sl_read_source`, `context_evidence_search`, `context_evidence_read`, `context_evidence_neighbors`, `emit_unmapped_fallback`, `eviction_list`, `emit_eviction_decision`.
+
+Not allowed: `context_candidate_write`, `context_candidate_mark`, `sl_write_source`, `sl_edit_source`, `sl_validate`.

--- a/packages/cli/src/status-project.ts
+++ b/packages/cli/src/status-project.ts
@@ -427,6 +427,21 @@ function buildConnectionStatus(
       const hint = envHint(tokenRef);
       return warn(hint ? `auth token missing (env: ${hint})` : 'auth token not set', hint ? `Set ${hint}` : 'Rerun `ktx setup`');
     }
+    case 'sharepoint': {
+      const tenantRef = (conn as Record<string, unknown>).tenant_id_ref;
+      const clientRef = (conn as Record<string, unknown>).client_id_ref;
+      const secretRef = (conn as Record<string, unknown>).client_secret_ref;
+      const tenant = resolveRef(tenantRef, env);
+      const client = resolveRef(clientRef, env);
+      const secret = resolveRef(secretRef, env);
+      const driveId = (conn as Record<string, unknown>).drive_id;
+      const folderId = (conn as Record<string, unknown>).folder_id;
+      if (tenant.resolved.length > 0 && client.resolved.length > 0 && secret.resolved.length > 0 && typeof driveId === 'string' && driveId.length > 0 && typeof folderId === 'string' && folderId.length > 0) {
+        return ok(`drive: ${driveId}, folder: ${folderId}`);
+      }
+      const hint = envHint(tenantRef) || envHint(clientRef) || envHint(secretRef)
+      return warn(hint ? `credentials missing (env: ${hint})` : 'credentials not set', hint ? `Set ${hint}` : 'Rerun `ktx setup`');
+    }
     case 'dbt':
     case 'dbt-core':
     case 'dbt-cloud': {
@@ -557,6 +572,7 @@ const ADAPTER_DRIVER_REQUIREMENT: Record<string, string[]> = {
   'live-database': ['postgres', 'mysql', 'snowflake', 'bigquery', 'clickhouse', 'sqlite', 'duckdb', 'sqlserver'],
   dbt: ['dbt', 'dbt-core', 'dbt-cloud'],
   notion: ['notion'],
+  sharepoint: ['sharepoint'],
   metabase: ['metabase'],
   looker: ['looker', 'lookml'],
   lookml: ['looker', 'lookml'],

--- a/packages/cli/test/connection-sharepoint.test.ts
+++ b/packages/cli/test/connection-sharepoint.test.ts
@@ -1,0 +1,123 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { initKtxProject } from '../src/context/project/project.js';
+import { parseKtxProjectConfig, serializeKtxProjectConfig } from '../src/context/project/config.js';
+import { runKtxConnection } from '../src/connection.js';
+
+function makeIo() {
+  let stdout = '';
+  let stderr = '';
+  return {
+    io: {
+      stdout: {
+        isTTY: true,
+        write: (chunk: string) => {
+          stdout += chunk;
+        },
+      },
+      stderr: {
+        write: (chunk: string) => {
+          stderr += chunk;
+        },
+      },
+    },
+    stdout: () => stdout,
+    stderr: () => stderr,
+  };
+}
+
+describe('runKtxConnection sharepoint', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'ktx-cli-connection-sharepoint-'));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  async function writeConnections(
+    projectDir: string,
+    connections: ReturnType<typeof parseKtxProjectConfig>['connections'],
+  ): Promise<void> {
+    const config = parseKtxProjectConfig(await readFile(join(projectDir, 'ktx.yaml'), 'utf-8'));
+    await writeFile(join(projectDir, 'ktx.yaml'), serializeKtxProjectConfig({ ...config, connections }), 'utf-8');
+  }
+
+  it('tests a SharePoint connection by verifying folder access and counting supported docs', async () => {
+    const projectDir = join(tempDir, 'project');
+    await initKtxProject({ projectDir });
+    await writeConnections(projectDir, {
+      docs_sharepoint: {
+        driver: 'sharepoint',
+        tenant_id_ref: 'env:AZURE_TENANT_ID',
+        client_id_ref: 'env:AZURE_CLIENT_ID',
+        client_secret_ref: 'env:AZURE_CLIENT_SECRET', // pragma: allowlist secret
+        drive_id: 'drive-123',
+        folder_id: 'folder-456',
+        recursive: true,
+      },
+    });
+    const createSharepointClient = vi.fn(async (_project, _connectionId) => ({
+      getDriveItem: vi.fn(async () => ({
+        id: 'folder-456',
+        name: 'Docs',
+        webUrl: null,
+        lastModifiedDateTime: null,
+        file: null,
+        folder: { childCount: 3 },
+        downloadUrl: null,
+      })),
+      listDriveFiles: vi.fn(async () => [
+        {
+          item: {
+            id: '1',
+            name: 'Spec.md',
+            webUrl: null,
+            lastModifiedDateTime: null,
+            file: { mimeType: 'text/markdown' },
+            folder: null,
+            downloadUrl: null,
+          },
+          drivePath: [],
+        },
+        {
+          item: {
+            id: '2',
+            name: 'Guide.docx',
+            webUrl: null,
+            lastModifiedDateTime: null,
+            file: { mimeType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' },
+            folder: null,
+            downloadUrl: null,
+          },
+          drivePath: [],
+        },
+        {
+          item: {
+            id: '3',
+            name: 'Diagram.png',
+            webUrl: null,
+            lastModifiedDateTime: null,
+            file: { mimeType: 'image/png' },
+            folder: null,
+            downloadUrl: null,
+          },
+          drivePath: [],
+        },
+      ]),
+    }));
+    const io = makeIo();
+
+    await expect(
+      runKtxConnection({ command: 'test', projectDir, connectionId: 'docs_sharepoint' }, io.io, { createSharepointClient }),
+    ).resolves.toBe(0);
+
+    expect(io.stdout()).toContain('Connection test passed: docs_sharepoint');
+    expect(io.stdout()).toContain('Driver: sharepoint');
+    expect(io.stdout()).toContain('Docs: 2');
+  });
+});

--- a/packages/cli/test/context/connections/sharepoint-config.test.ts
+++ b/packages/cli/test/context/connections/sharepoint-config.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  parseSharepointConnectionConfig,
+  sharepointConnectionToPullConfig,
+} from '../../../src/context/connections/sharepoint-config.js';
+
+describe('standalone sharepoint connection config', () => {
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+  });
+
+  it('parses config with safe defaults', () => {
+    const parsed = parseSharepointConnectionConfig({
+      driver: 'sharepoint',
+      tenant_id_ref: 'env:AZURE_TENANT_ID',
+      client_id_ref: 'env:AZURE_CLIENT_ID',
+      client_secret_ref: 'env:AZURE_CLIENT_SECRET', // pragma: allowlist secret
+      drive_id: 'drive-123',
+      folder_id: 'folder-456',
+    });
+
+    expect(parsed).toEqual({
+      driver: 'sharepoint',
+      tenant_id_ref: 'env:AZURE_TENANT_ID',
+      client_id_ref: 'env:AZURE_CLIENT_ID',
+      client_secret_ref: 'env:AZURE_CLIENT_SECRET', // pragma: allowlist secret
+      drive_id: 'drive-123',
+      folder_id: 'folder-456',
+      recursive: false,
+    });
+  });
+
+  it('requires env refs for all credential fields', () => {
+    expect(() =>
+      parseSharepointConnectionConfig({
+        driver: 'sharepoint',
+        tenant_id_ref: 'file:/tmp/tenant',
+        client_id_ref: 'env:AZURE_CLIENT_ID',
+        client_secret_ref: 'env:AZURE_CLIENT_SECRET', // pragma: allowlist secret
+        drive_id: 'drive-123',
+        folder_id: 'folder-456',
+      }),
+    ).toThrow('sharepoint tenant_id_ref must use env:NAME');
+  });
+
+  it('resolves env refs into adapter pull config', async () => {
+    const pullConfig = await sharepointConnectionToPullConfig(
+      parseSharepointConnectionConfig({
+        driver: 'sharepoint',
+        tenant_id_ref: 'env:AZURE_TENANT_ID',
+        client_id_ref: 'env:AZURE_CLIENT_ID',
+        client_secret_ref: 'env:AZURE_CLIENT_SECRET', // pragma: allowlist secret
+        drive_id: 'drive-123',
+        folder_id: 'folder-456',
+        recursive: true,
+      }),
+      {
+        env: {
+          AZURE_TENANT_ID: 'tenant-1',
+          AZURE_CLIENT_ID: 'client-1',
+          AZURE_CLIENT_SECRET: 'secret-1', // pragma: allowlist secret
+        },
+      },
+    );
+
+    expect(pullConfig).toEqual({
+      tenantId: 'tenant-1',
+      clientId: 'client-1',
+      clientSecret: 'secret-1', // pragma: allowlist secret
+      driveId: 'drive-123',
+      folderId: 'folder-456',
+      recursive: true,
+    });
+  });
+
+  it('fails clearly when an env var is unset', async () => {
+    await expect(
+      sharepointConnectionToPullConfig(
+        parseSharepointConnectionConfig({
+          driver: 'sharepoint',
+          tenant_id_ref: 'env:AZURE_TENANT_ID',
+          client_id_ref: 'env:AZURE_CLIENT_ID',
+          client_secret_ref: 'env:AZURE_CLIENT_SECRET', // pragma: allowlist secret
+          drive_id: 'drive-123',
+          folder_id: 'folder-456',
+        }),
+        { env: { AZURE_TENANT_ID: 'tenant-1', AZURE_CLIENT_ID: 'client-1' } },
+      ),
+    ).rejects.toThrow('SharePoint environment variable AZURE_CLIENT_SECRET is not set');
+  });
+});

--- a/packages/cli/test/context/ingest/adapters/sharepoint/chunk.test.ts
+++ b/packages/cli/test/context/ingest/adapters/sharepoint/chunk.test.ts
@@ -1,0 +1,68 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { chunkSharepointStagedDir } from '../../../../../src/context/ingest/adapters/sharepoint/chunk.js';
+
+describe('chunkSharepointStagedDir', () => {
+  let stagedDir: string;
+
+  beforeEach(async () => {
+    stagedDir = await mkdtemp(join(tmpdir(), 'ktx-sharepoint-chunk-'));
+  });
+
+  afterEach(async () => {
+    await rm(stagedDir, { recursive: true, force: true });
+  });
+
+  it('chunks changed documents into work units and normalizes diff paths', async () => {
+    await writeFile(
+      join(stagedDir, 'manifest.json'),
+      JSON.stringify({
+        source: 'sharepoint',
+        driveId: 'drive-1',
+        folderId: 'folder-1',
+        recursive: true,
+        fetchedAt: '2026-05-23T00:00:00.000Z',
+        fileCount: 1,
+        skipped: [],
+        warnings: [],
+      }),
+      'utf-8',
+    );
+    await mkdir(join(stagedDir, 'docs', 'team-docs', 'ops-handbook-abc123'), { recursive: true });
+    await writeFile(
+      join(stagedDir, 'docs', 'team-docs', 'ops-handbook-abc123', 'metadata.json'),
+      JSON.stringify({
+        id: 'file-1',
+        title: 'Ops Handbook',
+        path: 'Team Docs / Ops Handbook',
+        url: 'https://tenant.sharepoint.com/docs/ops',
+        mimeType: 'text/markdown',
+        driveId: 'drive-1',
+        folderId: 'folder-1',
+        drivePath: ['Team Docs'],
+        fileName: 'Ops Handbook.md',
+        lastModifiedDateTime: '2026-05-23T00:00:00.000Z',
+      }),
+      'utf-8',
+    );
+    await writeFile(join(stagedDir, 'docs', 'team-docs', 'ops-handbook-abc123', 'page.md'), '# Ops Handbook\n', 'utf-8');
+
+    const result = await chunkSharepointStagedDir(stagedDir, {
+      added: ['docs\\team-docs\\ops-handbook-abc123\\metadata.json', 'docs\\team-docs\\ops-handbook-abc123\\page.md'],
+      modified: [],
+      deleted: ['docs\\old-doc\\page.md'],
+      unchanged: ['manifest.json'],
+    });
+
+    expect(result.workUnits).toHaveLength(1);
+    expect(result.workUnits[0]).toMatchObject({
+      displayLabel: 'Team Docs / Ops Handbook',
+      rawFiles: ['docs/team-docs/ops-handbook-abc123/metadata.json', 'docs/team-docs/ops-handbook-abc123/page.md'],
+      dependencyPaths: ['manifest.json'],
+    });
+    expect(result.workUnits[0].notes).toContain('Do not create semantic-layer sources from sharepoint content in v1.');
+    expect(result.eviction).toEqual({ deletedRawPaths: ['docs/old-doc/page.md'] });
+  });
+});

--- a/packages/cli/test/context/ingest/adapters/sharepoint/detect.test.ts
+++ b/packages/cli/test/context/ingest/adapters/sharepoint/detect.test.ts
@@ -1,0 +1,22 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { detectSharepointStagedDir } from '../../../../../src/context/ingest/adapters/sharepoint/detect.js';
+
+describe('detectSharepointStagedDir', () => {
+  let stagedDir: string;
+
+  beforeEach(async () => {
+    stagedDir = await mkdtemp(join(tmpdir(), 'ktx-sharepoint-detect-'));
+  });
+
+  afterEach(async () => {
+    await rm(stagedDir, { recursive: true, force: true });
+  });
+
+  it('detects a manifest-backed sharepoint staged dir', async () => {
+    await writeFile(join(stagedDir, 'manifest.json'), JSON.stringify({ source: 'sharepoint' }), 'utf-8');
+    await expect(detectSharepointStagedDir(stagedDir)).resolves.toBe(true);
+  });
+});

--- a/packages/cli/test/context/ingest/adapters/sharepoint/fetch.test.ts
+++ b/packages/cli/test/context/ingest/adapters/sharepoint/fetch.test.ts
@@ -1,0 +1,124 @@
+import { createHash } from 'node:crypto';
+import { mkdtemp, readdir, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, relative } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { fetchSharepointSnapshot } from '../../../../../src/context/ingest/adapters/sharepoint/fetch.js';
+import { createDocxBuffer } from './test-docx.js';
+
+async function listRelativeFiles(root: string): Promise<string[]> {
+  const entries = await readdir(root, { recursive: true, withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isFile())
+    .map((entry) => relative(root, join(entry.parentPath, entry.name)).replace(/\\/g, '/'))
+    .sort();
+}
+
+function docDir(title: string, itemId: string): string {
+  const slug = title.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+  return `${slug}-${createHash('sha1').update(itemId).digest('hex').slice(0, 10)}`;
+}
+
+describe('fetchSharepointSnapshot', () => {
+  let stagedDir: string;
+
+  afterEach(async () => {
+    await rm(stagedDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('writes compact staged paths and preserves metadata for markdown and docx files', async () => {
+    stagedDir = await mkdtemp(join(tmpdir(), 'ktx-sharepoint-fetch-'));
+    const client = {
+      listDriveFiles: vi.fn(async () => [
+        {
+          item: {
+            id: 'file-md',
+            name: 'Ops Handbook.md',
+            webUrl: 'https://tenant.sharepoint.com/docs/ops',
+            lastModifiedDateTime: '2026-05-24T01:53:28.347Z',
+            file: { mimeType: 'text/markdown' },
+            folder: null,
+            downloadUrl: null,
+          },
+          drivePath: ['Team Docs'],
+        },
+        {
+          item: {
+            id: 'file-docx',
+            name: 'Quarterly Review.docx',
+            webUrl: 'https://tenant.sharepoint.com/docs/review',
+            lastModifiedDateTime: '2026-05-24T01:53:28.347Z',
+            file: { mimeType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' },
+            folder: null,
+            downloadUrl: null,
+          },
+          drivePath: [],
+        },
+        {
+          item: {
+            id: 'file-skip',
+            name: 'Diagram.png',
+            webUrl: null,
+            lastModifiedDateTime: '2026-05-24T01:53:28.347Z',
+            file: { mimeType: 'image/png' },
+            folder: null,
+            downloadUrl: null,
+          },
+          drivePath: [],
+        },
+      ]),
+      downloadFile: vi.fn(async (_driveId: string, item: { id: string }) => {
+        if (item.id === 'file-md') {
+          return Buffer.from('Line 1\r\nLine 2\r\n');
+        }
+        return createDocxBuffer(`<w:p><w:r><w:t>Durable review notes.</w:t></w:r></w:p>`);
+      }),
+    };
+
+    const manifest = await fetchSharepointSnapshot({
+      client: client as never,
+      config: {
+        tenantId: 'tenant-1',
+        clientId: 'client-1',
+        clientSecret: 'secret-1', // pragma: allowlist secret
+        driveId: 'drive-1',
+        folderId: 'folder-1',
+        recursive: true,
+      },
+      stagedDir,
+    });
+
+    expect(manifest.fileCount).toBe(2);
+    expect(manifest.skipped).toEqual([{ externalId: 'file-skip', reason: 'unsupported file extension: .png' }]);
+    expect(manifest.warnings[0]).toContain('Skipped 1 unsupported SharePoint / OneDrive file');
+
+    const files = await listRelativeFiles(stagedDir);
+    expect(files).toEqual([
+      `docs/${docDir('Quarterly Review', 'file-docx')}/metadata.json`,
+      `docs/${docDir('Quarterly Review', 'file-docx')}/page.md`,
+      `docs/team-docs/${docDir('Ops Handbook', 'file-md')}/metadata.json`,
+      `docs/team-docs/${docDir('Ops Handbook', 'file-md')}/page.md`,
+      'manifest.json',
+    ]);
+
+    const mdMetadata = JSON.parse(
+      await readFile(join(stagedDir, 'docs', 'team-docs', docDir('Ops Handbook', 'file-md'), 'metadata.json'), 'utf-8'),
+    );
+    expect(mdMetadata).toMatchObject({
+      id: 'file-md',
+      title: 'Ops Handbook',
+      path: 'Team Docs / Ops Handbook',
+      driveId: 'drive-1',
+      folderId: 'folder-1',
+      drivePath: ['Team Docs'],
+      fileName: 'Ops Handbook.md',
+    });
+    await expect(
+      readFile(join(stagedDir, 'docs', 'team-docs', docDir('Ops Handbook', 'file-md'), 'page.md'), 'utf-8'),
+    ).resolves.toBe('Line 1\nLine 2\n');
+    await expect(
+      readFile(join(stagedDir, 'docs', docDir('Quarterly Review', 'file-docx'), 'page.md'), 'utf-8'),
+    ).resolves.toContain('# Quarterly Review');
+  });
+});

--- a/packages/cli/test/context/ingest/adapters/sharepoint/graph-client.test.ts
+++ b/packages/cli/test/context/ingest/adapters/sharepoint/graph-client.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createSharepointGraphClient } from '../../../../../src/context/ingest/adapters/sharepoint/graph-client.js';
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+    ...init,
+  });
+}
+
+describe('SharepointGraphClient', () => {
+  afterEach(async () => {
+    vi.restoreAllMocks();
+  });
+
+  it('requests a token once and recursively paginates drive children', async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(jsonResponse({ access_token: 'graph-token' }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          value: [
+            { id: 'file-1', name: 'Root.md', file: { mimeType: 'text/markdown' } },
+            { id: 'folder-2', name: 'Subfolder', folder: { childCount: 1 } },
+          ],
+          '@odata.nextLink': 'https://graph.microsoft.com/v1.0/next-page',
+        }),
+      )
+      .mockResolvedValueOnce(jsonResponse({ value: [{ id: 'file-2', name: 'Root.docx', file: { mimeType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' } }] }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          value: [{ id: 'file-3', name: 'Nested.md', file: { mimeType: 'text/markdown' } }],
+        }),
+      );
+
+    const client = createSharepointGraphClient({
+      tenantId: 'tenant-1',
+      clientId: 'client-1',
+      clientSecret: 'secret-1', // pragma: allowlist secret
+      fetchImpl,
+    });
+    const files = await client.listDriveFiles({ driveId: 'drive-1', folderId: 'folder-1', recursive: true });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(4);
+    expect(fetchImpl.mock.calls[0]?.[0]).toBe('https://login.microsoftonline.com/tenant-1/oauth2/v2.0/token');
+    expect(files.map(({ item, drivePath }) => ({ id: item.id, path: drivePath.join('/') }))).toEqual([
+      { id: 'file-1', path: '' },
+      { id: 'file-2', path: 'Subfolder' },
+      { id: 'file-3', path: '' },
+    ]);
+  });
+
+  it('downloads file content from the direct download URL when present', async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(jsonResponse({ access_token: 'graph-token' }))
+      .mockResolvedValueOnce(new Response('document body', { status: 200 }));
+    const client = createSharepointGraphClient({
+      tenantId: 'tenant-1',
+      clientId: 'client-1',
+      clientSecret: 'secret-1', // pragma: allowlist secret
+      fetchImpl,
+    });
+
+    const content = await client.downloadFile('drive-1', {
+      id: 'file-1',
+      name: 'Ops.md',
+      webUrl: null,
+      lastModifiedDateTime: null,
+      file: { mimeType: 'text/markdown' },
+      folder: null,
+      downloadUrl: 'https://download.example/file-1',
+    });
+
+    expect(fetchImpl.mock.calls[1]?.[0]).toBe('https://download.example/file-1');
+    expect(content.toString('utf-8')).toBe('document body');
+  });
+
+  it('lists site drives across paginated results', async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(jsonResponse({ access_token: 'graph-token' }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          value: [{ id: 'drive-1', name: 'Documents', webUrl: 'https://tenant/sites/a/Documents' }],
+          '@odata.nextLink': 'https://graph.microsoft.com/v1.0/sites/site-1/drives?page=2',
+        }),
+      )
+      .mockResolvedValueOnce(jsonResponse({ value: [{ id: 'drive-2', name: 'Shared', webUrl: null }] }));
+    const client = createSharepointGraphClient({
+      tenantId: 'tenant-1',
+      clientId: 'client-1',
+      clientSecret: 'secret-1', // pragma: allowlist secret
+      fetchImpl,
+    });
+
+    await expect(client.listDrivesForSite('site-1')).resolves.toEqual([
+      { id: 'drive-1', name: 'Documents', webUrl: 'https://tenant/sites/a/Documents' },
+      { id: 'drive-2', name: 'Shared', webUrl: null },
+    ]);
+  });
+});

--- a/packages/cli/test/context/ingest/adapters/sharepoint/normalize.test.ts
+++ b/packages/cli/test/context/ingest/adapters/sharepoint/normalize.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeSharepointFileToMarkdown } from '../../../../../src/context/ingest/adapters/sharepoint/normalize.js';
+import { createDocxBuffer } from './test-docx.js';
+
+describe('normalizeSharepointFileToMarkdown', () => {
+  it('passes markdown through with normalized newlines and one trailing newline', () => {
+    expect(normalizeSharepointFileToMarkdown('ops.md', 'Line 1\r\nLine 2\r\n\r\n', 'Ops')).toBe('Line 1\nLine 2\n');
+  });
+
+  it('converts docx content into markdown with headings, lists, and tables', () => {
+    const buffer = createDocxBuffer(`
+      <w:p><w:pPr><w:pStyle w:val="Heading1"/></w:pPr><w:r><w:t>Ops Handbook</w:t></w:r></w:p>
+      <w:p><w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="1"/></w:numPr></w:pPr><w:r><w:t>First bullet</w:t></w:r></w:p>
+      <w:p><w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="2"/></w:numPr></w:pPr><w:r><w:t>First step</w:t></w:r></w:p>
+      <w:tbl>
+        <w:tr>
+          <w:tc><w:p><w:r><w:t>Name</w:t></w:r></w:p></w:tc>
+          <w:tc><w:p><w:r><w:t>Owner</w:t></w:r></w:p></w:tc>
+        </w:tr>
+        <w:tr>
+          <w:tc><w:p><w:r><w:t>Ops</w:t></w:r></w:p></w:tc>
+          <w:tc><w:p><w:r><w:t>Platform</w:t></w:r></w:p></w:tc>
+        </w:tr>
+      </w:tbl>
+    `);
+
+    const markdown = normalizeSharepointFileToMarkdown('ops.docx', buffer, 'Ops Handbook');
+    expect(markdown).toContain('# Ops Handbook');
+    expect(markdown).toContain('- First bullet');
+    expect(markdown).toContain('1. First step');
+    expect(markdown).toContain('| Name | Owner |');
+    expect(markdown).toContain('| Ops | Platform |');
+  });
+
+  it('prepends an H1 when converted docx content has no heading', () => {
+    const buffer = createDocxBuffer(`<w:p><w:r><w:t>Durable operating rules.</w:t></w:r></w:p>`);
+
+    expect(normalizeSharepointFileToMarkdown('ops.docx', buffer, 'Ops Handbook')).toBe(
+      '# Ops Handbook\n\nDurable operating rules.\n',
+    );
+  });
+});

--- a/packages/cli/test/context/ingest/adapters/sharepoint/sharepoint.adapter.test.ts
+++ b/packages/cli/test/context/ingest/adapters/sharepoint/sharepoint.adapter.test.ts
@@ -1,0 +1,55 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { SharepointSourceAdapter } from '../../../../../src/context/ingest/adapters/sharepoint/sharepoint.adapter.js';
+
+describe('SharepointSourceAdapter', () => {
+  let stagedDir: string;
+
+  beforeEach(async () => {
+    stagedDir = await mkdtemp(join(tmpdir(), 'ktx-sharepoint-adapter-'));
+  });
+
+  afterEach(async () => {
+    await rm(stagedDir, { recursive: true, force: true });
+  });
+
+  it('declares sharepoint source behavior', () => {
+    const adapter = new SharepointSourceAdapter();
+    expect(adapter.source).toBe('sharepoint');
+    expect(adapter.skillNames).toEqual(['sharepoint_synthesize']);
+    expect(adapter.reconcileSkillNames).toEqual([]);
+    expect(adapter.evidenceIndexing).toBe('documents');
+  });
+
+  it('detects a sharepoint staged dir from manifest source', async () => {
+    const adapter = new SharepointSourceAdapter();
+    await writeFile(join(stagedDir, 'manifest.json'), JSON.stringify({ source: 'sharepoint' }), 'utf-8');
+    await expect(adapter.detect(stagedDir)).resolves.toBe(true);
+  });
+
+  it('describes complete folder scope', async () => {
+    const adapter = new SharepointSourceAdapter();
+    await writeFile(
+      join(stagedDir, 'manifest.json'),
+      JSON.stringify({
+        source: 'sharepoint',
+        driveId: 'drive-1',
+        folderId: 'folder-1',
+        recursive: false,
+        fetchedAt: '2026-05-23T00:00:00.000Z',
+        fileCount: 0,
+        skipped: [],
+        warnings: [],
+      }),
+      'utf-8',
+    );
+    await mkdir(join(stagedDir, 'docs'), { recursive: true });
+
+    const scope = await adapter.describeScope?.(stagedDir);
+    expect(scope?.isPathInScope('manifest.json')).toBe(true);
+    expect(scope?.isPathInScope('docs/example/page.md')).toBe(true);
+    expect(scope?.isPathInScope('pages/example/page.md')).toBe(false);
+  });
+});

--- a/packages/cli/test/context/ingest/adapters/sharepoint/test-docx.ts
+++ b/packages/cli/test/context/ingest/adapters/sharepoint/test-docx.ts
@@ -1,0 +1,43 @@
+import { strToU8, zipSync } from 'fflate';
+
+export function createDocxBuffer(bodyXml: string, numberingXml = defaultNumberingXml()): Buffer {
+  const archive = zipSync({
+    '[Content_Types].xml': strToU8(
+      `<?xml version="1.0" encoding="UTF-8"?>
+      <Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+        <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+        <Default Extension="xml" ContentType="application/xml"/>
+        <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+        <Override PartName="/word/numbering.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.numbering+xml"/>
+      </Types>`,
+    ),
+    '_rels/.rels': strToU8(
+      `<?xml version="1.0" encoding="UTF-8"?>
+      <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+        <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+      </Relationships>`,
+    ),
+    'word/document.xml': strToU8(
+      `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+      <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:body>${bodyXml}</w:body>
+      </w:document>`,
+    ),
+    'word/numbering.xml': strToU8(numberingXml),
+  });
+  return Buffer.from(archive);
+}
+
+function defaultNumberingXml(): string {
+  return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+  <w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+    <w:abstractNum w:abstractNumId="1">
+      <w:lvl w:ilvl="0"><w:numFmt w:val="bullet"/></w:lvl>
+    </w:abstractNum>
+    <w:abstractNum w:abstractNumId="2">
+      <w:lvl w:ilvl="0"><w:numFmt w:val="decimal"/></w:lvl>
+    </w:abstractNum>
+    <w:num w:numId="1"><w:abstractNumId w:val="1"/></w:num>
+    <w:num w:numId="2"><w:abstractNumId w:val="2"/></w:num>
+  </w:numbering>`;
+}

--- a/packages/cli/test/context/ingest/ingest-runtime-assets.test.ts
+++ b/packages/cli/test/context/ingest/ingest-runtime-assets.test.ts
@@ -15,6 +15,7 @@ const adapterSkillNames = [
   'metricflow_ingest',
   'notion_synthesize',
   'gdrive_synthesize',
+  'sharepoint_synthesize',
   'historic_sql_table_digest',
   'historic_sql_patterns',
   'ingest_triage',

--- a/packages/cli/test/context/ingest/local-adapters-sharepoint.test.ts
+++ b/packages/cli/test/context/ingest/local-adapters-sharepoint.test.ts
@@ -1,0 +1,56 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { initKtxProject, loadKtxProject, type KtxLocalProject } from '../../../src/context/project/project.js';
+import { createDefaultLocalIngestAdapters, localPullConfigForAdapter } from '../../../src/context/ingest/local-adapters.js';
+
+describe('local sharepoint adapter wiring', () => {
+  let tempDir: string;
+  let project: KtxLocalProject;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'ktx-local-sharepoint-'));
+    const projectDir = join(tempDir, 'project');
+    await initKtxProject({ projectDir });
+    project = await loadKtxProject({ projectDir });
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('builds sharepoint pull config from a local connection', async () => {
+    vi.stubEnv('AZURE_TENANT_ID', 'tenant-1');
+    vi.stubEnv('AZURE_CLIENT_ID', 'client-1');
+    vi.stubEnv('AZURE_CLIENT_SECRET', 'secret-1'); // pragma: allowlist secret
+    const sharepointProject: KtxLocalProject = {
+      ...project,
+      config: {
+        ...project.config,
+        connections: {
+          docs_sharepoint: {
+            driver: 'sharepoint',
+            tenant_id_ref: 'env:AZURE_TENANT_ID',
+            client_id_ref: 'env:AZURE_CLIENT_ID',
+            client_secret_ref: 'env:AZURE_CLIENT_SECRET', // pragma: allowlist secret
+            drive_id: 'drive-123',
+            folder_id: 'folder-456',
+            recursive: true,
+          },
+        },
+      },
+    };
+
+    const adapter = createDefaultLocalIngestAdapters(sharepointProject).find((candidate) => candidate.source === 'sharepoint');
+    await expect(localPullConfigForAdapter(sharepointProject, adapter!, 'docs_sharepoint')).resolves.toEqual({
+      tenantId: 'tenant-1',
+      clientId: 'client-1',
+      clientSecret: 'secret-1', // pragma: allowlist secret
+      driveId: 'drive-123',
+      folderId: 'folder-456',
+      recursive: true,
+    });
+  });
+});

--- a/packages/cli/test/context/ingest/local-adapters.test.ts
+++ b/packages/cli/test/context/ingest/local-adapters.test.ts
@@ -75,6 +75,7 @@ describe('local ingest adapters', () => {
       'metabase',
       'sigma',
       'gdrive',
+      'sharepoint',
       'looker',
       'metricflow',
       'notion',

--- a/packages/cli/test/context/memory/memory-runtime-assets.test.ts
+++ b/packages/cli/test/context/memory/memory-runtime-assets.test.ts
@@ -17,6 +17,7 @@ const expectedSkillHeadings: Record<string, string> = {
 };
 const expectedAdapterSkillHeadings: Record<string, string> = {
   gdrive_synthesize: '# Google Drive Doc Synthesis',
+  sharepoint_synthesize: '# SharePoint / OneDrive Doc Synthesis',
   historic_sql_patterns: '# Historic SQL Patterns',
   historic_sql_table_digest: '# Historic SQL Table Digest',
   live_database_ingest: '# Live Database Ingest',
@@ -28,6 +29,7 @@ const expectedAdapterSkillHeadings: Record<string, string> = {
 };
 const verificationWriterSkills = [
   'gdrive_synthesize',
+  'sharepoint_synthesize',
   'notion_synthesize',
   'dbt_ingest',
   'lookml_ingest',
@@ -151,6 +153,14 @@ describe('memory runtime assets', () => {
     expect(body).toContain('Google Drive docs are knowledge-only in v1');
     expect(body).toContain('Do not create semantic-layer sources under the `gdrive` connection');
     expect(body).toContain('Source: Google Doc -');
+  });
+
+  it('ships SharePoint guidance for knowledge-only doc synthesis', async () => {
+    const body = await readFile(join(skillsDir, 'sharepoint_synthesize', 'SKILL.md'), 'utf-8');
+
+    expect(body).toContain('SharePoint docs are knowledge-only in v1');
+    expect(body).toContain('Do not create semantic-layer sources under the `sharepoint` connection');
+    expect(body).toContain('Source: SharePoint Doc -');
   });
 
   it('packages LookML connection-mismatch SL gate guidance', async () => {

--- a/packages/cli/test/context/project/driver-schemas-sharepoint.test.ts
+++ b/packages/cli/test/context/project/driver-schemas-sharepoint.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { connectionConfigSchema } from '../../../src/context/project/driver-schemas.js';
+
+describe('connectionConfigSchema - sharepoint', () => {
+  it('parses a sharepoint connection', () => {
+    const parsed = connectionConfigSchema.parse({
+      driver: 'sharepoint',
+      tenant_id_ref: 'env:AZURE_TENANT_ID',
+      client_id_ref: 'env:AZURE_CLIENT_ID',
+      client_secret_ref: 'env:AZURE_CLIENT_SECRET', // pragma: allowlist secret
+      drive_id: 'drive-123',
+      folder_id: 'folder-456',
+      recursive: true,
+    });
+
+    expect(parsed).toMatchObject({
+      driver: 'sharepoint',
+      tenant_id_ref: 'env:AZURE_TENANT_ID',
+      client_id_ref: 'env:AZURE_CLIENT_ID',
+      client_secret_ref: 'env:AZURE_CLIENT_SECRET', // pragma: allowlist secret
+      drive_id: 'drive-123',
+      folder_id: 'folder-456',
+      recursive: true,
+    });
+  });
+
+  it('rejects sharepoint connections with missing required ids', () => {
+    expect(() =>
+      connectionConfigSchema.parse({
+        driver: 'sharepoint',
+        tenant_id_ref: 'env:AZURE_TENANT_ID',
+        client_id_ref: 'env:AZURE_CLIENT_ID',
+        client_secret_ref: 'env:AZURE_CLIENT_SECRET', // pragma: allowlist secret
+        drive_id: '',
+        folder_id: 'folder-456',
+      }),
+    ).toThrow();
+  });
+});

--- a/packages/cli/test/public-ingest-sharepoint.test.ts
+++ b/packages/cli/test/public-ingest-sharepoint.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { buildDefaultKtxProjectConfig } from '../src/context/project/config.js';
+import { buildPublicIngestPlan, type KtxPublicIngestProject } from '../src/public-ingest.js';
+
+function projectWithConnections(connections: ReturnType<typeof buildDefaultKtxProjectConfig>['connections']): KtxPublicIngestProject {
+  const config = buildDefaultKtxProjectConfig();
+  return {
+    projectDir: '/tmp/project',
+    config: {
+      ...config,
+      connections,
+      llm: {
+        ...config.llm,
+        provider: { backend: 'gateway', gateway: { api_key: 'env:KTX_GATEWAY_API_KEY' } }, // pragma: allowlist secret
+        models: { default: 'gpt-test' },
+      },
+      scan: {
+        ...config.scan,
+        enrichment: {
+          mode: 'llm',
+          embeddings: {
+            backend: 'openai',
+            model: 'text-embedding-3-small',
+            dimensions: 1536,
+          },
+        },
+      },
+    },
+  };
+}
+
+describe('buildPublicIngestPlan sharepoint', () => {
+  it('maps sharepoint connections to the sharepoint source adapter', () => {
+    const project = projectWithConnections({
+      docs_sharepoint: {
+        driver: 'sharepoint',
+        tenant_id_ref: 'env:AZURE_TENANT_ID',
+        client_id_ref: 'env:AZURE_CLIENT_ID',
+        client_secret_ref: 'env:AZURE_CLIENT_SECRET', // pragma: allowlist secret
+        drive_id: 'drive-123',
+        folder_id: 'folder-456',
+      },
+    });
+
+    expect(buildPublicIngestPlan(project, { projectDir: '/tmp/project', all: true })).toEqual({
+      projectDir: '/tmp/project',
+      targets: [
+        {
+          connectionId: 'docs_sharepoint',
+          driver: 'sharepoint',
+          operation: 'source-ingest',
+          adapter: 'sharepoint',
+          debugCommand: 'ktx ingest docs_sharepoint --debug',
+          steps: ['source-ingest', 'memory-update'],
+        },
+      ],
+      warnings: [],
+    });
+  });
+});

--- a/packages/cli/test/setup-sources-sharepoint.test.ts
+++ b/packages/cli/test/setup-sources-sharepoint.test.ts
@@ -1,0 +1,96 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { initKtxProject } from '../src/context/project/project.js';
+import { parseKtxProjectConfig, serializeKtxProjectConfig } from '../src/context/project/config.js';
+import { runKtxSetupSourcesStep } from '../src/setup-sources.js';
+
+function makeIo() {
+  let stdout = '';
+  let stderr = '';
+  return {
+    io: {
+      stdout: {
+        isTTY: true,
+        write: (chunk: string) => {
+          stdout += chunk;
+        },
+      },
+      stderr: {
+        write: (chunk: string) => {
+          stderr += chunk;
+        },
+      },
+    },
+    stdout: () => stdout,
+    stderr: () => stderr,
+  };
+}
+
+describe('setup sources step sharepoint', () => {
+  let tempDir: string;
+  let projectDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'ktx-setup-sources-sharepoint-'));
+    projectDir = join(tempDir, 'project');
+    await initKtxProject({ projectDir });
+    const config = parseKtxProjectConfig(await readFile(join(projectDir, 'ktx.yaml'), 'utf-8'));
+    await writeFile(
+      join(projectDir, 'ktx.yaml'),
+      serializeKtxProjectConfig({
+        ...config,
+        connections: {
+          warehouse: { driver: 'postgres', url: 'env:DATABASE_URL' },
+        },
+        setup: {
+          ...config.setup,
+          database_connection_ids: ['warehouse'],
+        },
+      }),
+      'utf-8',
+    );
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('writes SharePoint config with env refs and recursive defaulting', async () => {
+    const validateSharepoint = vi.fn(async () => ({ ok: true as const, detail: 'docs=2' }));
+    const io = makeIo();
+
+    await expect(
+      runKtxSetupSourcesStep(
+        {
+          projectDir,
+          inputMode: 'disabled',
+          source: 'sharepoint',
+          sourceConnectionId: 'docs_sharepoint',
+          sharepointTenantIdRef: 'env:AZURE_TENANT_ID',
+          sharepointClientIdRef: 'env:AZURE_CLIENT_ID',
+          sharepointClientSecretRef: 'env:AZURE_CLIENT_SECRET', // pragma: allowlist secret
+          sharepointDriveId: 'drive-123',
+          sharepointFolderId: 'folder-456',
+          runInitialSourceIngest: false,
+          skipSources: false,
+        },
+        io.io,
+        { validateSharepoint },
+      ),
+    ).resolves.toEqual({ status: 'ready', projectDir, connectionIds: ['docs_sharepoint'] });
+
+    const config = parseKtxProjectConfig(await readFile(join(projectDir, 'ktx.yaml'), 'utf-8'));
+    expect(config.connections.docs_sharepoint).toMatchObject({
+      driver: 'sharepoint',
+      tenant_id_ref: 'env:AZURE_TENANT_ID',
+      client_id_ref: 'env:AZURE_CLIENT_ID',
+      client_secret_ref: 'env:AZURE_CLIENT_SECRET', // pragma: allowlist secret
+      drive_id: 'drive-123',
+      folder_id: 'folder-456',
+      recursive: false,
+    });
+  });
+});


### PR DESCRIPTION
  ## Summary

  This PR adds a new sharepoint context-source driver to ktx. It supports ingesting Markdown and Word documents from a
  Microsoft Graph drive folder, covering both SharePoint document libraries and OneDrive folders through the same
  drive_id + folder_id model.

  The implementation includes connection parsing, credential resolution, Graph-based folder traversal, staged ingest
  output, CLI setup and verification flows, runtime skill wiring, documentation, and test coverage.

  ## What was added

  ### New sharepoint context-source driver

  Added a new adapter under packages/cli/src/context/ingest/adapters/sharepoint/ with behavior aligned to the existing
  ingest stack:

  - Supports driver: sharepoint
  - Ingests .md and .docx files only
  - Traverses a Microsoft Graph drive folder, with optional recursion
  - Stages output as:
      - manifest.json
      - per-document metadata.json
      - per-document page.md

  - Uses stable compact staged directory names derived from document title and item ID

  ### Microsoft Graph authentication and connection resolution

  Added SharePoint connection resolution using Azure AD client credentials:

  - Resolves tenant_id_ref, client_id_ref, and client_secret_ref
  - Enforces env: references only for these credential fields
  - Exchanges credentials against the tenant-specific Microsoft identity token endpoint
  - Produces a lean pull config with resolved credentials plus driveId and folderId

  ### Graph-based file discovery and download

  Implemented a lightweight Graph client using native fetch:

  - Token acquisition
  - Folder children pagination
  - Recursive traversal of nested folders
  - File download for supported document types
  - Optional site-to-drive lookup during setup and verification when a site ID is provided

  ### Document conversion and normalization

  Added content handling for both supported formats:

  - .md files are preserved as authored Markdown with line-ending normalization
  - .docx files are converted to Markdown using mammoth
  - Converted Markdown is normalized for cleaner headings, lists, and pipe-table output
  - A leading H1 is added when converted Word content does not begin with one

  ### CLI and runtime integration

  Integrated the new source across user-facing CLI flows:

  - ktx connection can verify SharePoint credentials and folder access
  - ktx setup and source setup now support SharePoint-specific prompts and flags
  - Added runtime skill wiring through sharepoint_synthesize
  - Registered the driver in schemas, adapter resolution, public ingest mapping, and local ingest entrypoints

  ### Documentation

  Updated docs for configuration and usage:

  - docs-site/content/docs/integrations/context-sources.mdx
  - docs-site/content/docs/configuration/ktx-yaml.mdx

  Also documented required Microsoft Graph application permissions with admin consent:

  - Files.Read.All
  - Sites.Read.All

  ## Testing

  Added targeted coverage for the new SharePoint surface, including:

  - schema validation for sharepoint connection config
  - env-based credential resolution and error handling
  - Graph token acquisition, pagination, traversal, and download behavior
  - optional site-drive discovery
  - Markdown passthrough and .docx conversion behavior
  - staged output layout, manifest contents, and metadata generation
  - adapter detection, chunking, and scope description
  - setup flow, connection verification, and driver registration

  ## Verification

  Verified with:

  - targeted Vitest suites for SharePoint ingest, setup, connection, and schema coverage
  - pnpm --filter @kaelio/ktx run type-check
  - pnpm run dead-code

  Result:

  - SharePoint-specific implementation and tests passed
  - Type-check passed
  - Dead-code checks passed
  
  Close #171 
