### PR TITLE
Fix test expectation for stale sl query JSON file

### DIFF
--- a/packages/cli/test/sl.test.ts
+++ b/packages/cli/test/sl.test.ts
@@ -717,7 +717,17 @@ joins: []
 
     expect(query).toHaveBeenCalledWith(
       expect.objectContaining({
-        query: { measures: ['orders.order_count'], dimensions: [] },
+        dialect: 'postgres',
+        sources: expect.arrayContaining([
+          expect.objectContaining({
+            name: 'orders',
+            table: 'public.orders',
+          }),
+        ]),
+        query: expect.objectContaining({
+          measures: ['orders.order_count'],
+          dimensions: [],
+        }),
       }),
     );
     expect(JSON.parse(String(stdout.write.mock.calls[0][0]))).toMatchObject({


### PR DESCRIPTION
 ## Summary

  Updates the sl query JSON-file test to match the current compute.query(...) payload shape.

  The implementation now sends a fuller semantic-layer payload, including dialect and resolved sources, but the test in
  packages/cli/test/sl.test.ts was still asserting the older reduced shape. This caused the test to fail even though the
  runtime behavior was correct.

  ## What changed

  - Updated the runs sl query from a JSON query file assertion in packages/cli/test/sl.test.ts
  - Verified the test checks the current payload contract without duplicating lower-level policy-specific assertions

  ## Why

  This is a test-only fix. The underlying semantic-layer query path was already behaving correctly; the failure came
  from an outdated expectation.

  ## Verification

  Ran:

  pnpm --filter @kaelio/ktx exec vitest run test/sl.test.ts -t "runs sl query from a JSON query file" --testTimeout
  30000

  Result:

  - Passed
