### PR TITLE
fix(ci): repair slow sl test and sync uv.lock to 0.16.0

### DIFF
--- a/packages/cli/test/sl.test.ts
+++ b/packages/cli/test/sl.test.ts
@@ -717,7 +717,7 @@ joins: []
 
     expect(query).toHaveBeenCalledWith(
       expect.objectContaining({
-        query: { measures: ['orders.order_count'], dimensions: [] },
+        query: { measures: ['orders.order_count'], dimensions: [], predefined_measures_only: false },
       }),
     );
     expect(JSON.parse(String(stdout.write.mock.calls[0][0]))).toMatchObject({

--- a/uv.lock
+++ b/uv.lock
@@ -466,7 +466,7 @@ wheels = [
 
 [[package]]
 name = "ktx-daemon"
-version = "0.15.0"
+version = "0.16.0"
 source = { editable = "python/ktx-daemon" }
 dependencies = [
     { name = "fastapi" },
@@ -523,7 +523,7 @@ dev = [
 
 [[package]]
 name = "ktx-sl"
-version = "0.15.0"
+version = "0.16.0"
 source = { editable = "python/ktx-sl" }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
The **Slow TypeScript tests** CI job was red on `main`: the slow-only test `test/sl.test.ts > "runs sl query from a JSON query file"` asserted the outgoing `compute.query()` request with an exact nested `query` object, so the `predefined_measures_only` flag that the semantic-layer-only query policy (#334) now injects into every request broke the match. That test is excluded from the default `pnpm run test`, so #334 merged green while only the slow-test job caught it. This PR updates the assertion to expect `predefined_measures_only: false` (the default for a connection with no `query_policy`), restoring the request contract. It also syncs `uv.lock` to `0.16.0` for the editable `ktx-sl`/`ktx-daemon` packages, which the `0.16.0` release bumped in `pyproject.toml` but left stale in the lockfile.