### PR TITLE
feat(bigquery): support application default credentials

### DIFF
--- a/docs-site/content/docs/cli-reference/ktx-setup.mdx
+++ b/docs-site/content/docs/cli-reference/ktx-setup.mdx
@@ -123,6 +123,8 @@ runtime features are missing.
 | `--database <driver>` | Database driver to configure; repeatable. Choices: `sqlite`, `duckdb`, `postgres`, `mysql`, `clickhouse`, `sqlserver`, `bigquery`, `snowflake` |
 | `--database-connection-id <id>` | Existing selected connection id; repeatable. With `--database` or `--database-url`, connection id for the new connection. |
 | `--database-url <url>` | URL, `env:NAME`, or `file:/path` for one new URL-style database connection; also used as the SQLite or DuckDB path |
+| `--database-project-id <id>` | Billing project for one new BigQuery connection |
+| `--database-credentials <ref>` | Optional `env:NAME` or `file:/path` credential reference for BigQuery; omit to use ADC |
 | `--database-schema <schema>` | Database schema or dataset to include; repeatable |
 | `--skip-databases` | Leave database setup incomplete |
 
@@ -136,8 +138,8 @@ BigQuery; and `databases` for ClickHouse.
 
 A BigQuery `--database-schema` value may be qualified as `project.dataset` to
 scan a dataset hosted in another project (such as
-`bigquery-public-data.austin_311`); a bare value stays in the credentials'
-project. Setup does not discover foreign-project datasets, so supply qualified
+`bigquery-public-data.austin_311`); a bare value stays in the connection's
+`project_id`. Setup does not discover foreign-project datasets, so supply qualified
 entries explicitly. See
 [Primary sources → BigQuery](/docs/integrations/primary-sources#cross-project-datasets).
 

--- a/docs-site/content/docs/configuration/ktx-yaml.mdx
+++ b/docs-site/content/docs/configuration/ktx-yaml.mdx
@@ -111,7 +111,7 @@ context-source drivers share the map.
 | `sqlite` | Warehouse | `driver` | `url` or `path`, `enabled_tables` |
 | `duckdb` | Warehouse | `driver` | `url` or `path`, `enabled_tables` |
 | `sqlserver` | Warehouse | `driver` | `url`, `enabled_tables` |
-| `bigquery` | Warehouse | `driver` | `credentials_json`, `dataset_ids`, `enabled_tables`, `historicSql` |
+| `bigquery` | Warehouse | `driver`, `project_id` | `credentials_json`, `dataset_ids`, `enabled_tables`, `historicSql` |
 | `snowflake` | Warehouse | `driver` | `schema_names`, `enabled_tables`, `historicSql` |
 | `clickhouse` | Warehouse | `driver` | `url`, `database`, `databases`, `enabled_tables` |
 | `metabase` | Context source | `driver`, `api_url` | `api_key_ref`, `mappings` |
@@ -169,15 +169,15 @@ connections:
     databases: [analytics, mart]
   bigquery-warehouse:
     driver: bigquery
-    credentials_json: file:./service-account.json
+    project_id: my-gcp-project
     location: US
     dataset_ids: [analytics, mart]
 ```
 
 A BigQuery `dataset_ids` / `dataset_id` entry may be written `project.dataset`
 to introspect a dataset hosted in another project (for example
-`bigquery-public-data.austin_311`); jobs still bill to the `project_id` in
-`credentials_json`. A bare `dataset` keeps using your own project. See
+`bigquery-public-data.austin_311`); jobs still bill to the connection's
+`project_id`. A bare `dataset` keeps using that project. See
 [Primary sources → BigQuery](/docs/integrations/primary-sources#cross-project-datasets).
 
 For Postgres, MySQL, SQL Server, and Snowflake connections, set

--- a/docs-site/content/docs/integrations/primary-sources.mdx
+++ b/docs-site/content/docs/integrations/primary-sources.mdx
@@ -200,7 +200,7 @@ artifact shape as Postgres and BigQuery.
 
 ## BigQuery
 
-Authenticates via GCP service account credentials. Supports multi-dataset scanning and query-history configuration for `INFORMATION_SCHEMA.JOBS_BY_PROJECT`.
+Authenticates with Google Application Default Credentials (ADC) by default, with optional explicit service account credentials for workloads outside ADC-capable environments. Supports multi-dataset scanning and query-history configuration for `INFORMATION_SCHEMA.JOBS_BY_PROJECT`.
 
 ### Connection config
 
@@ -208,7 +208,7 @@ Authenticates via GCP service account credentials. Supports multi-dataset scanni
 connections:
   my-bigquery:
     driver: bigquery
-    credentials_json: file:~/.config/gcloud/bq-service-account.json
+    project_id: my-gcp-project
     dataset_id: analytics
     location: US
 ```
@@ -237,7 +237,7 @@ as `project.dataset`:
 connections:
   public-bq:
     driver: bigquery
-    credentials_json: file:~/.config/gcloud/bq-service-account.json
+    project_id: my-billing-project
     location: US
     dataset_ids:
       - bigquery-public-data.austin_311
@@ -246,8 +246,8 @@ connections:
 ```
 
 **ktx** introspects each dataset in its host project while every query job still
-bills to the `project_id` inside your `credentials_json`. A bare `dataset` entry
-(no prefix) is scanned in your own project, exactly as before. A single
+bills to the connection's `project_id`. A bare `dataset` entry (no prefix) is
+scanned in that project. A single
 connection may mix datasets from several projects, and two projects may host
 datasets with the same name without colliding.
 
@@ -261,13 +261,16 @@ cross-project dataset regardless of region.
 
 | Method | Config |
 |--------|--------|
+| Application Default Credentials | Set `project_id`; omit `credentials_json` |
 | Service account JSON | `credentials_json: file:/path/to/key.json` |
 | Environment variable | `credentials_json: env:BIGQUERY_CREDENTIALS_JSON` |
 
-The project ID is extracted automatically from the service account JSON file.
-If you set `project_id` in `ktx.yaml`, **ktx** treats it as local descriptor and
-mapping metadata. The BigQuery connector still authenticates with the
-`project_id` inside `credentials_json`.
+`project_id` is always required and determines where query jobs are billed. When
+`credentials_json` is omitted, Google's client library resolves ADC from the
+environment. On Google Cloud, assign a service identity to the workload. For a
+local shell, run `gcloud auth application-default login`. When
+`credentials_json` is present, **ktx** passes those explicit credentials to the
+client instead.
 
 ### Features
 

--- a/packages/cli/src/commands/setup-commands.ts
+++ b/packages/cli/src/commands/setup-commands.ts
@@ -109,6 +109,8 @@ function shouldShowSetupEntryMenu(
     database?: KtxSetupDatabaseDriver[];
     databaseConnectionId?: string[];
     databaseUrl?: string;
+    databaseProjectId?: string;
+    databaseCredentials?: string;
     databaseSchema?: string[];
     enableQueryHistory?: boolean;
     disableQueryHistory?: boolean;
@@ -181,6 +183,8 @@ function shouldShowSetupEntryMenu(
     'embeddingApiKeyFile',
     'skipEmbeddings',
     'databaseUrl',
+    'databaseProjectId',
+    'databaseCredentials',
     'enableQueryHistory',
     'disableQueryHistory',
     'queryHistoryWindowDays',
@@ -272,6 +276,15 @@ export function registerSetupCommands(program: Command, context: KtxCliCommandCo
     )
     .addOption(
       new Option('--database-url <url>', 'URL, env:NAME, or file:/path for one new URL-style database connection').hideHelp(),
+    )
+    .addOption(
+      new Option('--database-project-id <id>', 'Billing project for one new BigQuery connection').hideHelp(),
+    )
+    .addOption(
+      new Option(
+        '--database-credentials <ref>',
+        'Optional env:NAME or file:/path credential reference for one new BigQuery connection',
+      ).hideHelp(),
     )
     .addOption(
       new Option('--database-schema <schema>', 'Database schema to include; repeatable')
@@ -467,6 +480,8 @@ export function registerSetupCommands(program: Command, context: KtxCliCommandCo
         ? { databaseConnectionIds: options.databaseConnectionId }
         : {}),
       ...(options.databaseUrl ? { databaseUrl: options.databaseUrl } : {}),
+      ...(options.databaseProjectId ? { databaseProjectId: options.databaseProjectId } : {}),
+      ...(options.databaseCredentials ? { databaseCredentials: options.databaseCredentials } : {}),
       databaseSchemas: options.databaseSchema,
       ...(options.enableQueryHistory ? { enableQueryHistory: true } : {}),
       ...(options.disableQueryHistory ? { disableQueryHistory: true } : {}),

--- a/packages/cli/src/connectors/bigquery/connector.ts
+++ b/packages/cli/src/connectors/bigquery/connector.ts
@@ -36,6 +36,7 @@ import { resolveStringReference } from '../shared/string-reference.js';
 
 export interface KtxBigQueryConnectionConfig {
   driver?: string;
+  project_id?: string;
   dataset_id?: string;
   dataset_ids?: string[];
   credentials_json?: string;
@@ -47,9 +48,9 @@ export interface KtxBigQueryConnectionConfig {
 
 /**
  * A dataset to introspect, paired with the project that hosts it. `project`
- * defaults to the billing project (`credentials.project_id`) when an entry has
+ * defaults to the billing project (`project_id`) when an entry has
  * no `project.` prefix; a fully-qualified `project.dataset` entry resolves to
- * its own host project. Jobs always bill in `credentials.project_id`.
+ * its own host project. Jobs always bill in `project_id`.
  */
 export interface BigQueryDatasetRef {
   project: string;
@@ -58,7 +59,7 @@ export interface BigQueryDatasetRef {
 
 export interface KtxBigQueryResolvedConnectionConfig {
   projectId: string;
-  credentials: Record<string, unknown>;
+  credentials?: Record<string, unknown>;
   datasetIds: BigQueryDatasetRef[];
   location?: string;
 }
@@ -123,7 +124,7 @@ export interface KtxBigQueryClient {
 }
 
 export interface KtxBigQueryClientFactory {
-  createClient(input: { projectId: string; credentials: Record<string, unknown> }): KtxBigQueryClient;
+  createClient(input: { projectId: string; credentials?: Record<string, unknown> }): KtxBigQueryClient;
 }
 
 export interface KtxBigQueryScanConnectorOptions {
@@ -136,7 +137,7 @@ export interface KtxBigQueryScanConnectorOptions {
 }
 
 class DefaultBigQueryClientFactory implements KtxBigQueryClientFactory {
-  createClient(input: { projectId: string; credentials: Record<string, unknown> }): KtxBigQueryClient {
+  createClient(input: { projectId: string; credentials?: Record<string, unknown> }): KtxBigQueryClient {
     const client = new BigQuery(input);
     return {
       getDatasets: (options) => client.getDatasets(options) as Promise<[Array<{ id?: string }>, ...unknown[]]>,
@@ -321,18 +322,26 @@ export function bigQueryConnectionConfigFromConfig(input: {
   }
 
   const env = input.env ?? process.env;
+  const configuredProjectId = stringConfigValue(input.connection, 'project_id', env);
+  if (!configuredProjectId) {
+    throw new Error(`Native BigQuery connector requires connections.${input.connectionId}.project_id`);
+  }
+  const projectId = normalizeBigQueryProjectId(
+    configuredProjectId,
+    `connections.${input.connectionId}.project_id`,
+  );
   const credentialsJson = stringConfigValue(input.connection, 'credentials_json', env);
-  if (!credentialsJson) {
-    throw new Error(`Native BigQuery connector requires connections.${input.connectionId}.credentials_json`);
-  }
-  const credentials = JSON.parse(credentialsJson) as Record<string, unknown>;
-  const projectId = typeof credentials.project_id === 'string' ? credentials.project_id : undefined;
-  if (!projectId) {
-    throw new Error(`Native BigQuery connector requires credentials_json.project_id for connections.${input.connectionId}`);
-  }
+  const credentials = credentialsJson
+    ? (JSON.parse(credentialsJson) as Record<string, unknown>)
+    : undefined;
   const resolvedDatasetIds = resolveDatasetRefs(input.connection, env, projectId, input.connectionId);
   const location = stringConfigValue(input.connection, 'location', env);
-  return { projectId, credentials, datasetIds: resolvedDatasetIds, ...(location ? { location } : {}) };
+  return {
+    projectId,
+    ...(credentials ? { credentials } : {}),
+    datasetIds: resolvedDatasetIds,
+    ...(location ? { location } : {}),
+  };
 }
 
 export class KtxBigQueryScanConnector implements KtxScanConnector {
@@ -543,7 +552,7 @@ export class KtxBigQueryScanConnector implements KtxScanConnector {
     if (!this.client) {
       this.client = this.clientFactory.createClient({
         projectId: this.resolved.projectId,
-        credentials: this.resolved.credentials,
+        ...(this.resolved.credentials ? { credentials: this.resolved.credentials } : {}),
       });
     }
     return this.client;

--- a/packages/cli/src/context/ingest/historic-sql-probes/bigquery-runner.ts
+++ b/packages/cli/src/context/ingest/historic-sql-probes/bigquery-runner.ts
@@ -6,8 +6,8 @@ import {
   type HistoricSqlProbeRunner,
   type HistoricSqlSuccessDetail,
 } from '../historic-sql-probes.js';
-import { resolveKtxConfigReference } from '../../core/config-reference.js';
 import {
+  bigQueryConnectionConfigFromConfig,
   isKtxBigQueryConnectionConfig,
   KtxBigQueryScanConnector,
   type KtxBigQueryConnectionConfig,
@@ -30,28 +30,6 @@ interface BigQueryJobsByProjectProbeRunnerOptions {
   createClient?: (
     input: HistoricSqlProbeInput & { connection: KtxBigQueryConnectionConfig },
   ) => ClientHandle;
-  resolveReference?: (value: string | undefined, env: NodeJS.ProcessEnv) => string | undefined;
-}
-
-function bigQueryProjectId(
-  connectionId: string,
-  connection: KtxBigQueryConnectionConfig,
-  env: NodeJS.ProcessEnv,
-  resolveReference: (value: string | undefined, env: NodeJS.ProcessEnv) => string | undefined,
-): string {
-  const rawCredentials =
-    typeof connection.credentials_json === 'string' ? connection.credentials_json : '';
-  const resolvedCredentials = resolveReference(rawCredentials, env);
-  if (!resolvedCredentials) {
-    throw new Error(`Query history BigQuery connection ${connectionId} requires credentials_json`);
-  }
-  const parsed = JSON.parse(resolvedCredentials) as { project_id?: unknown };
-  if (typeof parsed.project_id !== 'string' || parsed.project_id.trim().length === 0) {
-    throw new Error(
-      `Query history BigQuery connection ${connectionId} requires credentials_json.project_id`,
-    );
-  }
-  return parsed.project_id;
 }
 
 function bigQueryRegion(connection: KtxBigQueryConnectionConfig): string {
@@ -74,11 +52,6 @@ export class BigQueryJobsByProjectProbeRunner implements HistoricSqlProbeRunner 
   private readonly createClient: (
     input: HistoricSqlProbeInput & { connection: KtxBigQueryConnectionConfig },
   ) => ClientHandle;
-  private readonly resolveReference: (
-    value: string | undefined,
-    env: NodeJS.ProcessEnv,
-  ) => string | undefined;
-
   constructor(options: BigQueryJobsByProjectProbeRunnerOptions = {}) {
     this.createReader =
       options.createReader ??
@@ -108,7 +81,6 @@ export class BigQueryJobsByProjectProbeRunner implements HistoricSqlProbeRunner 
           cleanup: () => connector.cleanup(),
         };
       });
-    this.resolveReference = options.resolveReference ?? resolveKtxConfigReference;
   }
 
   async run(input: HistoricSqlProbeInput): Promise<GenericProbeResult> {
@@ -116,12 +88,11 @@ export class BigQueryJobsByProjectProbeRunner implements HistoricSqlProbeRunner 
     if (!isKtxBigQueryConnectionConfig(input.connection)) {
       throw new Error(`Native BigQuery connector cannot run driver "${inputDriver}"`);
     }
-    const projectId = bigQueryProjectId(
-      input.connectionId,
-      input.connection,
-      input.env ?? process.env,
-      this.resolveReference,
-    );
+    const projectId = bigQueryConnectionConfigFromConfig({
+      connectionId: input.connectionId,
+      connection: input.connection,
+      env: input.env,
+    }).projectId;
     const reader = this.createReader({
       projectId,
       region: bigQueryRegion(input.connection),

--- a/packages/cli/src/local-adapters.ts
+++ b/packages/cli/src/local-adapters.ts
@@ -1,7 +1,12 @@
 import { createAthenaLiveDatabaseIntrospection } from './connectors/athena/live-database-introspection.js';
 import { isKtxAthenaConnectionConfig } from './connectors/athena/connector.js';
 import { createBigQueryLiveDatabaseIntrospection } from './connectors/bigquery/live-database-introspection.js';
-import { isKtxBigQueryConnectionConfig, KtxBigQueryScanConnector, type KtxBigQueryConnectionConfig } from './connectors/bigquery/connector.js';
+import {
+  bigQueryConnectionConfigFromConfig,
+  isKtxBigQueryConnectionConfig,
+  KtxBigQueryScanConnector,
+  type KtxBigQueryConnectionConfig,
+} from './connectors/bigquery/connector.js';
 import { createClickHouseLiveDatabaseIntrospection } from './connectors/clickhouse/live-database-introspection.js';
 import { isKtxClickHouseConnectionConfig } from './connectors/clickhouse/connector.js';
 import { createMysqlLiveDatabaseIntrospection } from './connectors/mysql/live-database-introspection.js';
@@ -38,7 +43,6 @@ import {
   type ManagedPythonDaemonHttpOptions,
 } from './managed-python-http.js';
 import type { KtxOperationalLogger } from './io/logger.js';
-import { resolveKtxConfigReference } from './context/core/config-reference.js';
 
 function hasSnowflakeDriver(connection: unknown): boolean {
   return (
@@ -278,20 +282,7 @@ async function createEphemeralSnowflakeHistoricSqlClient(
   };
 }
 
-function bigQueryProjectId(connection: KtxBigQueryConnectionConfig, env: NodeJS.ProcessEnv): string {
-  const raw = typeof connection.credentials_json === 'string' ? connection.credentials_json : '';
-  const resolved = resolveKtxConfigReference(raw, env);
-  if (!resolved) {
-    throw new Error('Query history BigQuery connection requires credentials_json');
-  }
-  const parsed = JSON.parse(resolved) as { project_id?: unknown };
-  if (typeof parsed.project_id !== 'string' || parsed.project_id.trim().length === 0) {
-    throw new Error('Query history BigQuery connection requires credentials_json.project_id');
-  }
-  return parsed.project_id;
-}
-
-function bigQueryRegion(connection: KtxBigQueryConnectionConfig): string {
+function bigQueryRegion(connection: Record<string, unknown>): string {
   return typeof connection.location === 'string' && connection.location.trim().length > 0
     ? connection.location.trim()
     : 'us';
@@ -338,7 +329,10 @@ function historicSqlOptionsForLocalRun(
       ...base,
       dialect,
       reader: new BigQueryHistoricSqlQueryHistoryReader({
-        projectId: bigQueryProjectId(connection, process.env),
+        projectId: bigQueryConnectionConfigFromConfig({
+          connectionId,
+          connection,
+        }).projectId,
         region: bigQueryRegion(connection),
       }) satisfies HistoricSqlReader,
       queryClient: createEphemeralBigQueryHistoricSqlClient(project, connectionId),

--- a/packages/cli/src/setup-databases.ts
+++ b/packages/cli/src/setup-databases.ts
@@ -85,6 +85,8 @@ export interface KtxSetupDatabasesArgs {
   databaseConnectionIds?: string[];
   databaseConnectionId?: string;
   databaseUrl?: string;
+  databaseProjectId?: string;
+  databaseCredentials?: string;
   databaseSchemas: string[];
   enableQueryHistory?: boolean;
   disableQueryHistory?: boolean;
@@ -856,22 +858,45 @@ async function buildConnectionConfig(input: {
     });
   }
   if (driver === 'bigquery') {
-    const credentialsPath = await promptText(
-      prompts,
-      'Path to service account JSON file',
-      displayFileReference(stringConfigField(input.existingConnection, 'credentials_json')),
-    );
-    if (credentialsPath === undefined) return 'back';
-    const location = await promptText(
-      prompts,
-      'BigQuery location\nPress Enter for US, or enter a location like EU.',
-      stringConfigField(input.existingConnection, 'location') ?? 'US',
-    );
+    if (args.inputMode === 'disabled' && !args.databaseProjectId) return null;
+    const projectId =
+      args.databaseProjectId ??
+      (await promptText(
+        prompts,
+        'BigQuery billing project ID',
+        stringConfigField(input.existingConnection, 'project_id'),
+      ));
+    if (projectId === undefined) return 'back';
+    if (!projectId) return null;
+    const credentials = args.databaseCredentials
+      ? normalizeInputReference(args.databaseCredentials)
+      : args.inputMode === 'disabled'
+        ? undefined
+        : await promptText(
+            prompts,
+            'Optional path to service account JSON file\nPress Enter to use Application Default Credentials.',
+            displayFileReference(stringConfigField(input.existingConnection, 'credentials_json')),
+          );
+    if (credentials === undefined && args.inputMode !== 'disabled') return 'back';
+    const location =
+      args.inputMode === 'disabled'
+        ? stringConfigField(input.existingConnection, 'location') ?? 'US'
+        : await promptText(
+            prompts,
+            'BigQuery location\nPress Enter for US, or enter a location like EU.',
+            stringConfigField(input.existingConnection, 'location') ?? 'US',
+          );
     if (location === undefined) return 'back';
-    if (!credentialsPath) return null;
     return {
       driver: 'bigquery',
-      credentials_json: normalizeFileReference(credentialsPath),
+      project_id: projectId,
+      ...(credentials
+        ? {
+            credentials_json: args.databaseCredentials
+              ? credentials
+              : normalizeFileReference(credentials),
+          }
+        : {}),
       ...(location ? { location } : {}),
       ...scriptedScopeConfigForDriver('bigquery', args.databaseSchemas),
     };

--- a/packages/cli/src/setup.ts
+++ b/packages/cli/src/setup.ts
@@ -100,6 +100,8 @@ export type KtxSetupArgs =
       databaseConnectionIds?: string[];
       databaseConnectionId?: string;
       databaseUrl?: string;
+      databaseProjectId?: string;
+      databaseCredentials?: string;
       databaseSchemas: string[];
       enableQueryHistory?: boolean;
       disableQueryHistory?: boolean;
@@ -832,6 +834,8 @@ async function runKtxSetupInner(args: KtxSetupArgs, io: KtxCliIo, deps: KtxSetup
             ...(args.databaseConnectionIds ? { databaseConnectionIds: args.databaseConnectionIds } : {}),
             ...(args.databaseConnectionId ? { databaseConnectionId: args.databaseConnectionId } : {}),
             ...(args.databaseUrl ? { databaseUrl: args.databaseUrl } : {}),
+            ...(args.databaseProjectId ? { databaseProjectId: args.databaseProjectId } : {}),
+            ...(args.databaseCredentials ? { databaseCredentials: args.databaseCredentials } : {}),
             databaseSchemas: args.databaseSchemas,
             ...(args.enableQueryHistory !== undefined ? { enableQueryHistory: args.enableQueryHistory } : {}),
             ...(args.disableQueryHistory !== undefined ? { disableQueryHistory: args.disableQueryHistory } : {}),

--- a/packages/cli/src/status-project.ts
+++ b/packages/cli/src/status-project.ts
@@ -407,10 +407,23 @@ function buildConnectionStatus(
       return warn('account not set', 'Rerun `ktx setup`');
     }
     case 'bigquery': {
+      const project = resolveRef((conn as Record<string, unknown>).project_id, env);
+      if (project.resolved.length === 0) {
+        const hint = envHint((conn as Record<string, unknown>).project_id);
+        return warn(
+          hint ? `project id missing (env: ${hint})` : 'project_id not set',
+          hint ? `Set ${hint}` : 'Set project_id for this BigQuery connection',
+        );
+      }
+      const credentialsRef = (conn as Record<string, unknown>).credentials_json;
+      if (credentialsRef === undefined) return ok(`ADC configured for project: ${project.resolved}`);
       const cred = resolveRef((conn as Record<string, unknown>).credentials_json, env);
-      if (cred.resolved.length > 0) return ok('credentials configured');
+      if (cred.resolved.length > 0) return ok(`credentials configured for project: ${project.resolved}`);
       const hint = envHint((conn as Record<string, unknown>).credentials_json);
-      return warn(hint ? `credentials missing (env: ${hint})` : 'credentials not set', hint ? `Set ${hint}` : 'Rerun `ktx setup`');
+      return warn(
+        hint ? `credentials missing (env: ${hint})` : 'credentials reference is empty',
+        hint ? `Set ${hint}` : 'Remove credentials_json to use ADC',
+      );
     }
     case 'duckdb':
     case 'sqlite': {

--- a/packages/cli/test/connectors/bigquery/connector.test.ts
+++ b/packages/cli/test/connectors/bigquery/connector.test.ts
@@ -93,6 +93,7 @@ function fakeClientFactory(options: { primaryKeyError?: Error } = {}): KtxBigQue
 
 const connection = {
   driver: 'bigquery',
+  project_id: 'project-1',
   dataset_id: 'analytics',
   credentials_json: JSON.stringify({ project_id: 'project-1', client_email: 'reader@example.test' }),
   location: 'US',
@@ -120,12 +121,42 @@ describe('KtxBigQueryScanConnector', () => {
     });
   });
 
+  it('uses Application Default Credentials when credentials_json is omitted', async () => {
+    const clientFactory = fakeClientFactory();
+    const connector = new KtxBigQueryScanConnector({
+      connectionId: 'warehouse',
+      connection: {
+        driver: 'bigquery',
+        project_id: 'project-1',
+        dataset_id: 'analytics',
+      },
+      clientFactory,
+    });
+
+    await expect(connector.testConnection()).resolves.toEqual({ success: true });
+    expect(clientFactory.createClient).toHaveBeenCalledWith({ projectId: 'project-1' });
+  });
+
+  it('requires an explicit billing project for every authentication method', () => {
+    expect(() =>
+      bigQueryConnectionConfigFromConfig({
+        connectionId: 'warehouse',
+        connection: {
+          driver: 'bigquery',
+          dataset_id: 'analytics',
+          credentials_json: JSON.stringify({ project_id: 'credential-project' }),
+        },
+      }),
+    ).toThrow('connections.warehouse.project_id');
+  });
+
   it('parses project.dataset entries to host-project pairs and rejects malformed entries', () => {
     expect(
       bigQueryConnectionConfigFromConfig({
         connectionId: 'warehouse',
         connection: {
           driver: 'bigquery',
+          project_id: 'project-1',
           dataset_ids: ['bigquery-public-data.austin_311', 'analytics'],
           credentials_json: JSON.stringify({ project_id: 'project-1' }),
         },
@@ -141,6 +172,7 @@ describe('KtxBigQueryScanConnector', () => {
           connectionId: 'warehouse',
           connection: {
             driver: 'bigquery',
+            project_id: 'project-1',
             dataset_ids: [badEntry],
             credentials_json: JSON.stringify({ project_id: 'project-1' }),
           },
@@ -220,6 +252,7 @@ describe('KtxBigQueryScanConnector', () => {
       connectionId: 'warehouse',
       connection: {
         driver: 'bigquery',
+        project_id: 'project-1',
         dataset_ids: ['bigquery-public-data.austin_311'],
         credentials_json: JSON.stringify({ project_id: 'project-1' }),
         location: 'US',
@@ -250,6 +283,7 @@ describe('KtxBigQueryScanConnector', () => {
       connectionId: 'warehouse',
       connection: {
         driver: 'bigquery',
+        project_id: 'project-1',
         dataset_ids: ['bigquery-public-data.austin_311', 'analytics'],
         credentials_json: JSON.stringify({ project_id: 'project-1' }),
         location: 'US',
@@ -276,6 +310,7 @@ describe('KtxBigQueryScanConnector', () => {
       connectionId: 'warehouse',
       connection: {
         driver: 'bigquery',
+        project_id: 'project-1',
         dataset_ids: ['proj_a.shared', 'proj_b.shared'],
         credentials_json: JSON.stringify({ project_id: 'project-1' }),
       },
@@ -522,6 +557,7 @@ describe('KtxBigQueryScanConnector', () => {
       connectionId: 'warehouse',
       connection: {
         driver: 'bigquery',
+        project_id: 'project-1',
         credentials_json: JSON.stringify({ project_id: 'project-1' }),
         location: 'US',
       },
@@ -551,6 +587,7 @@ describe('KtxBigQueryScanConnector', () => {
       connectionId: 'warehouse',
       connection: {
         driver: 'bigquery',
+        project_id: 'project-1',
         credentials_json: JSON.stringify({ project_id: 'project-1' }),
         location: 'US',
       },

--- a/packages/cli/test/context/connections/drivers.test.ts
+++ b/packages/cli/test/context/connections/drivers.test.ts
@@ -53,6 +53,7 @@ const connectionFixtures: Record<KtxConnectionDriver, FixtureFactory> = {
   }),
   bigquery: () => ({
     driver: 'bigquery',
+    project_id: 'project-1',
     dataset_id: 'analytics',
     credentials_json: JSON.stringify({
       project_id: 'project-1',

--- a/packages/cli/test/context/ingest/historic-sql-probes/bigquery-runner.test.ts
+++ b/packages/cli/test/context/ingest/historic-sql-probes/bigquery-runner.test.ts
@@ -12,7 +12,6 @@ describe('BigQueryJobsByProjectProbeRunner', () => {
     const runner = new BigQueryJobsByProjectProbeRunner({
       createReader,
       createClient: () => ({ client: { executeQuery: vi.fn() }, cleanup }),
-      resolveReference: () => '{"project_id":"project-1"}',
     });
 
     await expect(
@@ -21,7 +20,7 @@ describe('BigQueryJobsByProjectProbeRunner', () => {
         connectionId: 'bq',
         connection: {
           driver: 'bigquery',
-          credentials_json: 'env:BQ_CREDENTIALS_JSON',
+          project_id: 'project-1',
           location: 'EU',
         },
         env: {},
@@ -39,7 +38,6 @@ describe('BigQueryJobsByProjectProbeRunner', () => {
     const runner = new BigQueryJobsByProjectProbeRunner({
       createReader,
       createClient: () => ({ client: {}, cleanup: vi.fn(async () => undefined) }),
-      resolveReference: () => '{"project_id":"project-1"}',
     });
 
     await runner.run({
@@ -47,7 +45,7 @@ describe('BigQueryJobsByProjectProbeRunner', () => {
       connectionId: 'bq',
       connection: {
         driver: 'bigquery',
-        credentials_json: '{"project_id":"project-1"}',
+        project_id: 'project-1',
       },
       env: {},
     });
@@ -55,11 +53,10 @@ describe('BigQueryJobsByProjectProbeRunner', () => {
     expect(createReader).toHaveBeenCalledWith({ projectId: 'project-1', region: 'us' });
   });
 
-  it('rejects missing BigQuery credentials_json.project_id', async () => {
+  it('rejects a missing BigQuery project_id', async () => {
     const runner = new BigQueryJobsByProjectProbeRunner({
       createReader: vi.fn(),
       createClient: () => ({ client: {}, cleanup: vi.fn() }),
-      resolveReference: () => '{"client_email":"svc@example.test"}',
     });
 
     await expect(
@@ -68,11 +65,10 @@ describe('BigQueryJobsByProjectProbeRunner', () => {
         connectionId: 'bq',
         connection: {
           driver: 'bigquery',
-          credentials_json: 'env:BQ_CREDENTIALS_JSON',
         },
         env: {},
       }),
-    ).rejects.toThrow('Query history BigQuery connection bq requires credentials_json.project_id');
+    ).rejects.toThrow('connections.bq.project_id');
   });
 
   it('formats successful BigQuery details', () => {

--- a/packages/cli/test/local-adapters.test.ts
+++ b/packages/cli/test/local-adapters.test.ts
@@ -211,16 +211,16 @@ describe('CLI local ingest adapters', () => {
     expect(adapters.some((adapter) => adapter.source === 'historic-sql')).toBe(true);
   });
 
-  it('registers BigQuery historic SQL from the requested connection', async () => {
+  it('registers BigQuery historic SQL with Application Default Credentials', async () => {
     await writeProject(
       tempDir,
       [
         'connections:',
         '  bq:',
         '    driver: bigquery',
+        '    project_id: demo-project',
         '    dataset_id: analytics',
         '    location: us',
-        '    credentials_json: \'{"project_id":"demo-project"}\'',
         '    context:',
         '      queryHistory:',
         '        enabled: true',
@@ -287,6 +287,7 @@ describe('CLI local ingest adapters', () => {
         'connections:',
         '  bq:',
         '    driver: bigquery',
+        '    project_id: demo-project',
         '    dataset_id: analytics',
         '    location: us',
         `    credentials_json: 'file:${credentialsPath}'`,
@@ -312,7 +313,7 @@ describe('CLI local ingest adapters', () => {
     ]);
   });
 
-  it('uses query-history wording for public BigQuery capability errors', async () => {
+  it('uses the canonical BigQuery project validation for query history ingest', async () => {
     await writeProject(
       tempDir,
       [
@@ -321,7 +322,6 @@ describe('CLI local ingest adapters', () => {
         '    driver: bigquery',
         '    readonly: true',
         '    dataset_id: analytics',
-        '    credentials_json: "{}"',
         '    context:',
         '      queryHistory:',
         '        enabled: true',
@@ -338,6 +338,6 @@ describe('CLI local ingest adapters', () => {
         historicSqlConnectionId: 'bq',
         sqlAnalysis: sqlAnalysisStub(),
       }),
-    ).toThrow('Query history BigQuery connection requires credentials_json.project_id');
+    ).toThrow('connections.bq.project_id');
   });
 });

--- a/packages/cli/test/setup-databases.test.ts
+++ b/packages/cli/test/setup-databases.test.ts
@@ -569,7 +569,7 @@ describe('setup databases step', () => {
       {
         driver: 'bigquery',
         selectValues: ['no'],
-        textValues: ['', '/path/to/service-account.json', ''],
+        textValues: ['', 'project-1', '/path/to/service-account.json', ''],
         expectedTextPrompts: [
           {
             message: connectionNamePrompt('BigQuery'),
@@ -577,7 +577,10 @@ describe('setup databases step', () => {
             initialValue: 'bigquery-warehouse',
           },
           {
-            message: 'Path to service account JSON file',
+            message: 'BigQuery billing project ID',
+          },
+          {
+            message: 'Optional path to service account JSON file\nPress Enter to use Application Default Credentials.',
           },
           {
             message: 'BigQuery location\nPress Enter for US, or enter a location like EU.',
@@ -2029,7 +2032,7 @@ describe('setup databases step', () => {
     const prompts = makePromptAdapter({
       multiselectValues: [['bigquery']],
       selectValues: ['no', 'continue'],
-      textValues: ['bigquery-warehouse', '/tmp/service-account.json', 'US'],
+      textValues: ['bigquery-warehouse', 'project-1', '/tmp/service-account.json', 'US'],
     });
     const listSchemas = vi.fn(async () => ['analytics']);
     const listTables = vi.fn(async () => [{ catalog: 'project-1', schema: 'analytics', name: 'orders', kind: 'table' as const }]);
@@ -2240,6 +2243,7 @@ describe('setup databases step', () => {
         'connections:',
         '  bigquery-warehouse:',
         '    driver: bigquery',
+        '    project_id: project-1',
         '    dataset_ids:',
         "      - 'sales'",
         '    credentials_json: env:BIGQUERY_CREDENTIALS_JSON',
@@ -2272,6 +2276,32 @@ describe('setup databases step', () => {
       driver: 'bigquery',
       dataset_ids: ['sales'],
     });
+  });
+
+  it('adds a non-interactive BigQuery connection that uses Application Default Credentials', async () => {
+    const result = await runKtxSetupDatabasesStep(
+      {
+        projectDir: tempDir,
+        inputMode: 'disabled',
+        databaseDrivers: ['bigquery'],
+        databaseConnectionId: 'analytics',
+        databaseProjectId: 'project-1',
+        databaseSchemas: ['analytics'],
+        skipDatabases: false,
+      },
+      makeIo().io,
+      { testConnection: vi.fn(async () => 0), scanConnection: vi.fn(async () => 0) },
+    );
+
+    expect(result.status).toBe('ready');
+    const config = parseKtxProjectConfig(await readFile(join(tempDir, 'ktx.yaml'), 'utf-8'));
+    expect(config.connections.analytics).toMatchObject({
+      driver: 'bigquery',
+      project_id: 'project-1',
+      dataset_ids: ['analytics'],
+      location: 'US',
+    });
+    expect(config.connections.analytics).not.toHaveProperty('credentials_json');
   });
 
   it('preserves existing Postgres schemas in non-interactive setup without rediscovering', async () => {
@@ -3101,6 +3131,7 @@ describe('setup databases step', () => {
         'connections:',
         '  analytics:',
         '    driver: bigquery',
+        '    project_id: project-1',
         '    dataset_id: analytics',
         '    credentials_json: env:BIGQUERY_CREDENTIALS_JSON',
         '',
@@ -3169,6 +3200,7 @@ describe('setup databases step', () => {
         'connections:',
         '  analytics:',
         '    driver: bigquery',
+        '    project_id: project-1',
         '    dataset_id: analytics',
         '    credentials_json: env:BIGQUERY_CREDENTIALS_JSON',
         '',

--- a/packages/cli/test/status-project.test.ts
+++ b/packages/cli/test/status-project.test.ts
@@ -151,6 +151,28 @@ describe('buildProjectStatus embeddings', () => {
   });
 });
 
+describe('buildProjectStatus BigQuery authentication', () => {
+  it('reports Application Default Credentials when project_id is set without credentials_json', async () => {
+    const config = baseProjectConfig();
+    config.connections.analytics = {
+      driver: 'bigquery',
+      project_id: 'project-1',
+      dataset_ids: ['analytics'],
+    };
+
+    const status = await buildProjectStatus(projectWithConfig(config), {
+      claudeCodeAuthProbe: stubClaudeCodeAuthProbe,
+    });
+
+    expect(status.connections).toContainEqual({
+      name: 'analytics',
+      driver: 'bigquery',
+      status: 'ok',
+      detail: 'ADC configured for project: project-1',
+    });
+  });
+});
+
 function withPostgresQueryHistory(config: KtxProjectConfig): KtxProjectConfig {
   return {
     ...config,
@@ -190,6 +212,7 @@ function withBigQueryQueryHistory(config: KtxProjectConfig): KtxProjectConfig {
       ...config.connections,
       bq: {
         driver: 'bigquery',
+        project_id: 'project-1',
         credentials_json: 'env:BQ_CREDENTIALS_JSON',
         context: { queryHistory: { enabled: true } },
       } as KtxProjectConfig['connections'][string],

--- a/skills/ktx/SKILL.md
+++ b/skills/ktx/SKILL.md
@@ -54,7 +54,8 @@ Before invoking `ktx setup`, collect in one round:
    no key; use `openai` only if the user already has a key, then pass
    `--embedding-api-key-env OPENAI_API_KEY`).
 4. Database: driver, connection id, URL (or `env:` / `file:` ref), and one or
-   more schemas.
+   more schemas. For BigQuery, collect the billing project id and use ADC by
+   default; collect a credential reference only when ADC is unavailable.
 5. Optional context sources (dbt, Metabase, Looker, LookML, MetricFlow,
    Notion). Add each one with a follow-up `ktx setup --source …` run (see
    [Add context sources](#add-context-sources)); use `--skip-sources` only
@@ -84,6 +85,21 @@ Do not discover these inputs across multiple setup runs.
      --database <driver> --database-connection-id <id> \
      --database-url '<raw-url | file:/abs/path>' \
      --database-schema <schema> \
+     --skip-sources \
+     --skip-agents
+   ```
+
+   For BigQuery, replace `--database-url` with the billing project flag. Omit
+   `--database-credentials` to use Application Default Credentials:
+
+   ```bash
+   ktx setup --no-input --yes \
+     --project-dir <path> \
+     --llm-backend claude-code \
+     --embedding-backend sentence-transformers \
+     --database bigquery --database-connection-id <id> \
+     --database-project-id <project-id> \
+     --database-schema <dataset> \
      --skip-sources \
      --skip-agents
    ```


### PR DESCRIPTION
## Summary

- require an explicit BigQuery `project_id` as the canonical billing project
- use Google Application Default Credentials when `credentials_json` is omitted
- retain explicit credential references as an override for non-ADC environments
- route live queries, scanning, local query-history ingest, and query-history probes through the same resolver
- make interactive and non-interactive setup ADC-first and update status, docs, and the public skill

## Verification

- focused BigQuery connector, setup, status, local adapter, and query-history tests
- complete default `@kaelio/ktx` CLI test suite
- workspace type-check
- production build
- Biome and Knip dead-code checks
- live `ktx connection test` against BigQuery using local ADC with no `credentials_json`

## Configuration

```yaml
connections:
  warehouse:
    driver: bigquery
    project_id: my-gcp-project
    dataset_ids:
      - analytics
```

Cloud-hosted workloads can now use their assigned service identity without distributing a long-lived service-account key.