### PR TITLE
fix(scan): exclude per-scan extractedAt and warnings from enrichment stage hashes

### DIFF
--- a/packages/cli/src/context/scan/enrichment-state.ts
+++ b/packages/cli/src/context/scan/enrichment-state.ts
@@ -99,13 +99,25 @@ export interface KtxRelationshipsStageHashInput {
   llmIdentity: KtxScanLlmIdentity;
 }
 
+/**
+ * Snapshot content that identifies a schema for stage hashing. `extractedAt`
+ * is a fresh wall-clock timestamp on every scan and `warnings` are per-run
+ * diagnostics; hashing either would re-key every stage on each scan of an
+ * unchanged schema (see `stableLiveDatabaseHashContent` for the ingest-side
+ * equivalent).
+ */
+function stableSnapshotHashContent(snapshot: KtxSchemaSnapshot): Omit<KtxSchemaSnapshot, 'extractedAt' | 'warnings'> {
+  const { extractedAt: _extractedAt, warnings: _warnings, ...stable } = snapshot;
+  return stable;
+}
+
 export function computeKtxDescriptionsStageHash(input: KtxDescriptionsStageHashInput): string {
-  return stableContentHash({ snapshot: input.snapshot, llmIdentity: input.llmIdentity });
+  return stableContentHash({ snapshot: stableSnapshotHashContent(input.snapshot), llmIdentity: input.llmIdentity });
 }
 
 export function computeKtxEmbeddingsStageHash(input: KtxEmbeddingsStageHashInput): string {
   return stableContentHash({
-    snapshot: input.snapshot,
+    snapshot: stableSnapshotHashContent(input.snapshot),
     embeddingIdentity: input.embeddingIdentity,
     descriptionDigest: input.descriptionDigest,
   });
@@ -113,7 +125,7 @@ export function computeKtxEmbeddingsStageHash(input: KtxEmbeddingsStageHashInput
 
 export function computeKtxRelationshipsStageHash(input: KtxRelationshipsStageHashInput): string {
   return stableContentHash({
-    snapshot: input.snapshot,
+    snapshot: stableSnapshotHashContent(input.snapshot),
     relationshipSettings: input.relationshipSettings,
     llmIdentity: input.llmIdentity,
   });

--- a/packages/cli/test/context/scan/enrichment-state.test.ts
+++ b/packages/cli/test/context/scan/enrichment-state.test.ts
@@ -84,6 +84,53 @@ describe('scan enrichment state', () => {
     expect(changed).not.toBe(first);
   });
 
+  // Regression for #347: a rescan of an unchanged schema stamps a fresh
+  // extractedAt (and may carry per-run warnings); stage hashes must not move,
+  // or every scan re-runs all enrichment LLM calls.
+  it('ignores per-scan extractedAt and warnings so an unchanged schema hashes equal across scans', () => {
+    const rescanned: KtxSchemaSnapshot = {
+      ...snapshot,
+      extractedAt: '2026-04-29T13:30:00.000Z',
+      warnings: [{ code: 'sampling_failed', message: 'transient sampling failure', recoverable: true }],
+    };
+    const descriptionDigest = computeKtxScanDescriptionDigest(['orders.id (integer)']);
+
+    expect(computeKtxDescriptionsStageHash({ snapshot: rescanned, llmIdentity })).toBe(
+      computeKtxDescriptionsStageHash({ snapshot, llmIdentity }),
+    );
+    expect(computeKtxEmbeddingsStageHash({ snapshot: rescanned, embeddingIdentity, descriptionDigest })).toBe(
+      computeKtxEmbeddingsStageHash({ snapshot, embeddingIdentity, descriptionDigest }),
+    );
+    expect(computeKtxRelationshipsStageHash({ snapshot: rescanned, relationshipSettings, llmIdentity })).toBe(
+      computeKtxRelationshipsStageHash({ snapshot, relationshipSettings, llmIdentity }),
+    );
+
+    // A real schema change must still re-key every stage.
+    const firstTable = snapshot.tables[0];
+    const firstColumn = firstTable?.columns[0];
+    if (!firstTable || !firstColumn) {
+      throw new Error('Expected test snapshot table with a column');
+    }
+    const changedColumn: KtxSchemaSnapshot = {
+      ...rescanned,
+      tables: [
+        {
+          ...firstTable,
+          columns: [...firstTable.columns, { ...firstColumn, name: 'status', primaryKey: false }],
+        },
+      ],
+    };
+    expect(computeKtxDescriptionsStageHash({ snapshot: changedColumn, llmIdentity })).not.toBe(
+      computeKtxDescriptionsStageHash({ snapshot, llmIdentity }),
+    );
+    expect(computeKtxEmbeddingsStageHash({ snapshot: changedColumn, embeddingIdentity, descriptionDigest })).not.toBe(
+      computeKtxEmbeddingsStageHash({ snapshot, embeddingIdentity, descriptionDigest }),
+    );
+    expect(computeKtxRelationshipsStageHash({ snapshot: changedColumn, relationshipSettings, llmIdentity })).not.toBe(
+      computeKtxRelationshipsStageHash({ snapshot, relationshipSettings, llmIdentity }),
+    );
+  });
+
   it('isolates per-stage invalidation: one input changes only its own stage', () => {
     const descriptionDigest = computeKtxScanDescriptionDigest(['orders.id (integer)']);
     const descriptions = computeKtxDescriptionsStageHash({ snapshot, llmIdentity });


### PR DESCRIPTION
Fixes #347

Makes rescans of an unchanged schema hit the enrichment resume caches instead of re-sending every table and column description to the LLM.

Every connector stamps a fresh `extractedAt` on each introspection, and that timestamp (plus any per-run `warnings`) was folded into the descriptions/embeddings/relationships stage hashes via the whole-snapshot hash. A rescan therefore always produced a new `inputHash`, both persistent caches (the SQLite stage cache and `enrichment-progress/descriptions.json`) missed, and enrichment restarted from zero — the repeated ~4-minute description runs in the issue.

## Approach

`enrichment-state.ts` now hashes only schema-identifying snapshot content: a shared `stableSnapshotHashContent` helper strips `extractedAt` (fresh wall-clock per scan) and `warnings` (per-run diagnostics, e.g. one transient failed sample would otherwise re-key every stage) before hashing, and all three stage-hash functions route through it. This mirrors what `stableLiveDatabaseHashContent` in `local-stage-ingest.ts` already does for the ingest work-unit cache. No enrichment stage reads either field, so the hash loses no discriminating content, and a real schema change (added/renamed column) still re-keys.

Existing caches re-key once after upgrading (the hashed content shape changed); rescans are stable from then on.

## Tests

- New regression test: two snapshots differing only in `extractedAt`/`warnings` hash identically for all three stages, and an added column still re-keys all three. Fails on `main`, passes here.
- Before/after check against the built package: with `dist` from `main`, a fresh `extractedAt` re-keyed all three stages; with this change all three hashes are stable.
- `type-check`, CLI test suite, and `dead-code` (biome + knip default + production) pass. I developed on Windows, where ~60 test files fail on `main` for pre-existing environment reasons (sqlite `EBUSY` on temp-dir cleanup, doubled `Z:\Z:\` drive prefix in benchmark fixture paths); I diffed failing-file sets between `main` and this branch on the same machine to confirm no new failures. Happy to file those Windows issues separately.

## Out of scope

Per-table checkpointing so a scope/schema change only regenerates changed tables — tracked in #348.
