### PR TITLE
fix(sl): project dotted physical columns to contract-valid aliases

### DIFF
--- a/packages/cli/src/context/connections/local-warehouse-descriptor.ts
+++ b/packages/cli/src/context/connections/local-warehouse-descriptor.ts
@@ -34,6 +34,22 @@ const DRIVER_TO_CONNECTION_TYPE: Record<string, ConnectionType> = {
   athena: 'ATHENA',
 };
 
+const CONNECTION_TYPE_TO_DRIVER: Record<string, string> = Object.fromEntries(
+  Object.entries(DRIVER_TO_CONNECTION_TYPE).map(([driver, connectionType]) => [connectionType, driver]),
+);
+
+/**
+ * Scan-driver name for a catalog `connectionType`. Accepts both the descriptor
+ * form (`POSTGRESQL`) and the driver form (`postgres`) — non-warehouse
+ * connections fall back to their driver string in `connectionType`.
+ */
+export function driverForConnectionType(connectionType: string | undefined): string | null {
+  if (!connectionType) {
+    return null;
+  }
+  return CONNECTION_TYPE_TO_DRIVER[connectionType.toUpperCase()] ?? connectionType.toLowerCase();
+}
+
 export function localConnectionToWarehouseDescriptor(
   id: string,
   connection: KtxProjectConnectionConfig | undefined,

--- a/packages/cli/src/context/sl/local-sl.ts
+++ b/packages/cli/src/context/sl/local-sl.ts
@@ -9,8 +9,10 @@ import type { SearchCandidateGenerator } from '../../context/search/types.js';
 import { DEFAULT_PRIORITY, resolveDescription } from './descriptions.js';
 import { normalizeSemanticLayerDescriptions } from './description-normalization.js';
 import { sourceDefinitionSchema, sourceOverlaySchema } from './schemas.js';
+import { localConnectionInfoFromConfig } from '../connections/local-warehouse-descriptor.js';
 import {
   composeOverlay,
+  manifestIdentifierQuoterForConnectionType,
   type ManifestTableEntry,
   projectManifestEntry,
   SemanticLayerService,
@@ -207,6 +209,9 @@ async function loadSingleConnectionSourceRecords(
   const listed = await project.fileStore.listFiles(dir);
   const paths = listed.files.filter(isSlYamlPath).sort();
   const sources = new Map<string, LocalSlSourceRecord>();
+  const quoteIdentifier = manifestIdentifierQuoterForConnectionType(
+    localConnectionInfoFromConfig(connectionId, project.config.connections[connectionId])?.connectionType,
+  );
 
   for (const path of paths.filter((file) => file.startsWith(`${schemaDir}/`))) {
     const raw = await project.fileStore.readFile(path);
@@ -220,7 +225,7 @@ async function loadSingleConnectionSourceRecords(
       continue;
     }
     for (const [name, entry] of Object.entries(tables)) {
-      const source = projectManifestEntry(name, entry);
+      const source = projectManifestEntry(name, entry, quoteIdentifier);
       const projectedPath = `${path}#${name}`;
       sources.set(name, {
         ...summarizeSemanticSource({ connectionId, path: projectedPath, source }),

--- a/packages/cli/src/context/sl/semantic-layer.service.ts
+++ b/packages/cli/src/context/sl/semantic-layer.service.ts
@@ -3,6 +3,8 @@ import type { KtxFileStorePort } from '../../context/core/file-store.js';
 import type { KtxLogger } from '../../context/core/config.js';
 import { noopLogger } from '../../context/core/config.js';
 import { dialectForConnectionType } from '../connections/connection-type-dialect.js';
+import { getSqlDialectForDriver, isSqlQueryableDriver } from '../connections/dialects.js';
+import { driverForConnectionType } from '../connections/local-warehouse-descriptor.js';
 import type { TableUsageOutput } from '../ingest/adapters/historic-sql/skill-schemas.js';
 import type { SlConnectionCatalogPort, SlPythonPort } from './ports.js';
 import { normalizeSemanticLayerDescriptions } from './description-normalization.js';
@@ -92,12 +94,32 @@ export function toResolvedWire(source: SemanticLayerSource): ResolvedSemanticLay
 }
 
 export class SemanticLayerService {
+  private readonly manifestQuoters = new Map<string, ManifestIdentifierQuoter | null>();
+
   constructor(
     private readonly configService: KtxFileStorePort,
     private readonly connections: SlConnectionCatalogPort,
     private readonly python: SlPythonPort,
     private readonly logger: KtxLogger = noopLogger,
   ) {}
+
+  // An unknown or unresolvable connection projects without a quoter: its
+  // sources stay searchable, and querying it fails earlier at executeQuery.
+  private async manifestQuoterFor(connectionId: string): Promise<ManifestIdentifierQuoter | null> {
+    const cached = this.manifestQuoters.get(connectionId);
+    if (cached !== undefined) {
+      return cached;
+    }
+    let connectionType: string | undefined;
+    try {
+      connectionType = (await this.connections.getConnectionById(connectionId))?.connectionType;
+    } catch {
+      connectionType = undefined;
+    }
+    const quoter = manifestIdentifierQuoterForConnectionType(connectionType);
+    this.manifestQuoters.set(connectionId, quoter);
+    return quoter;
+  }
 
   /**
    * Return a clone of this service whose disk reads/writes go through a worktree-scoped
@@ -269,6 +291,7 @@ export class SemanticLayerService {
     // 1. Load manifest shards from _schema/*.yaml → project to sources
     const sources = new Map<string, SemanticLayerSource>();
     const schemaFiles = allFiles.filter((f) => f.startsWith(`${schemaDir}/`));
+    const quoteIdentifier = await this.manifestQuoterFor(connectionId);
 
     for (const filePath of schemaFiles) {
       try {
@@ -276,7 +299,7 @@ export class SemanticLayerService {
         const shard = YAML.parse(content) as { tables?: Record<string, ManifestTableEntry> };
         if (shard?.tables) {
           for (const [name, entry] of Object.entries(shard.tables)) {
-            sources.set(name, projectManifestEntry(name, entry));
+            sources.set(name, projectManifestEntry(name, entry, quoteIdentifier));
           }
         }
       } catch (e) {
@@ -442,7 +465,7 @@ export class SemanticLayerService {
           const shard = YAML.parse(content) as { tables?: Record<string, ManifestTableEntry> };
           const entry = shard?.tables?.[sourceName];
           if (entry) {
-            return projectManifestEntry(sourceName, entry);
+            return projectManifestEntry(sourceName, entry, await this.manifestQuoterFor(connectionId));
           }
         } catch {
           // skip unparseable shards
@@ -491,7 +514,7 @@ export class SemanticLayerService {
         for (const [name, entry] of Object.entries(shard.tables)) {
           const tablePath = entry.table?.toLowerCase() ?? '';
           if (tablePath === lowered || tablePath.endsWith(dotSuffix)) {
-            return projectManifestEntry(name, entry);
+            return projectManifestEntry(name, entry, await this.manifestQuoterFor(connectionId));
           }
         }
       } catch {
@@ -854,8 +877,9 @@ export class SemanticLayerService {
       try {
         const { content } = await this.configService.readFile(filePath);
         const shard = YAML.parse(content) as { tables?: Record<string, ManifestTableEntry> };
+        const quoteIdentifier = await this.manifestQuoterFor(connectionId);
         for (const [name, entry] of Object.entries(shard?.tables ?? {})) {
-          entries.push({ connectionId, source: projectManifestEntry(name, entry) });
+          entries.push({ connectionId, source: projectManifestEntry(name, entry, quoteIdentifier) });
         }
       } catch {
         // skip unparseable shards
@@ -1195,19 +1219,66 @@ export interface ManifestTableEntry {
   usage?: TableUsageOutput;
 }
 
-export function projectManifestEntry(name: string, entry: ManifestTableEntry): SemanticLayerSource {
+export type ManifestIdentifierQuoter = (identifier: string) => string;
+
+/**
+ * Native-dialect identifier quoter for manifest projection, or null for
+ * non-SQL connections (their sources are searchable but never SQL-queried).
+ * The Python planner parses column `expr` in the connection's dialect, so the
+ * physical reference must be quoted with that dialect's identifier character.
+ */
+export function manifestIdentifierQuoterForConnectionType(
+  connectionType: string | undefined,
+): ManifestIdentifierQuoter | null {
+  const driver = driverForConnectionType(connectionType);
+  if (!driver || !isSqlQueryableDriver(driver)) {
+    return null;
+  }
+  const dialect = getSqlDialectForDriver(driver);
+  return (identifier) => dialect.quoteIdentifier(identifier);
+}
+
+// Physical column names may legally contain '.' (quoted warehouse identifiers,
+// MongoDB field names), but the contract requires unqualified output names — a
+// dot in `name` reads as a table qualification (#337). Dotted physical names
+// get a deterministic '_' alias; the physical reference survives in `expr`.
+function manifestColumnRenames(physicalNames: readonly string[]): Map<string, string> {
+  const renames = new Map<string, string>();
+  const taken = new Set(physicalNames.filter((name) => !name.includes('.')));
+  for (const name of physicalNames) {
+    if (!name.includes('.') || renames.has(name)) {
+      continue;
+    }
+    const base = name.replace(/\./g, '_');
+    let candidate = base;
+    for (let suffix = 2; taken.has(candidate); suffix += 1) {
+      candidate = `${base}_${suffix}`;
+    }
+    taken.add(candidate);
+    renames.set(name, candidate);
+  }
+  return renames;
+}
+
+export function projectManifestEntry(
+  name: string,
+  entry: ManifestTableEntry,
+  quoteIdentifier: ManifestIdentifierQuoter | null,
+): SemanticLayerSource {
+  const renames = manifestColumnRenames(entry.columns.map((c) => c.name));
   const columns = entry.columns.map((c) => ({
-    name: c.name,
+    name: renames.get(c.name) ?? c.name,
     type: c.type,
     role: c.type === 'time' ? 'time' : undefined,
     descriptions: c.descriptions,
     constraints: c.constraints,
     enum_values: c.enum_values,
     tests: c.tests,
+    ...(renames.has(c.name) && quoteIdentifier ? { expr: quoteIdentifier(c.name) } : {}),
   }));
 
-  const pkColumns = entry.columns.filter((c) => c.pk).map((c) => c.name);
-  const grain = pkColumns.length > 0 ? pkColumns : entry.columns.map((c) => c.name);
+  const pkColumns = entry.columns.filter((c) => c.pk).map((c) => renames.get(c.name) ?? c.name);
+  const grain = pkColumns.length > 0 ? pkColumns : columns.map((c) => c.name);
 
   // Table-level dbt config from manifest shards is surfaced on the source for search / tools.
   const source: SemanticLayerSource = {

--- a/packages/cli/test/context/sl/semantic-layer.service.test.ts
+++ b/packages/cli/test/context/sl/semantic-layer.service.test.ts
@@ -11,6 +11,7 @@ import {
   ConflictingExcludeAndOverrideError,
   enrichColumnsFromManifest,
   findDanglingSegmentRefs,
+  manifestIdentifierQuoterForConnectionType,
   projectManifestEntry,
   SemanticLayerService,
   toResolvedWire,
@@ -589,19 +590,23 @@ describe('toResolvedWire', () => {
 
 describe('projectManifestEntry', () => {
   it('projects manifest usage onto the semantic-layer source', () => {
-    const source = projectManifestEntry('orders', {
-      table: 'public.orders',
-      usage: {
-        narrative: 'Orders are frequently filtered by status.',
-        frequencyTier: 'high',
-        commonFilters: ['status'],
-        commonJoins: [{ table: 'public.customers', on: ['customer_id'] }],
+    const source = projectManifestEntry(
+      'orders',
+      {
+        table: 'public.orders',
+        usage: {
+          narrative: 'Orders are frequently filtered by status.',
+          frequencyTier: 'high',
+          commonFilters: ['status'],
+          commonJoins: [{ table: 'public.customers', on: ['customer_id'] }],
+        },
+        columns: [
+          { name: 'id', type: 'string', pk: true },
+          { name: 'status', type: 'string' },
+        ],
       },
-      columns: [
-        { name: 'id', type: 'string', pk: true },
-        { name: 'status', type: 'string' },
-      ],
-    });
+      null,
+    );
 
     expect(source.usage).toEqual({
       narrative: 'Orders are frequently filtered by status.',
@@ -609,6 +614,84 @@ describe('projectManifestEntry', () => {
       commonFilters: ['status'],
       commonJoins: [{ table: 'public.customers', on: ['customer_id'] }],
     });
+  });
+
+  // Regression for #337: physical column names may contain '.' (quoted
+  // warehouse identifiers, MongoDB fields). Projection must emit
+  // contract-valid output names or the source hard-fails on every query.
+  it('aliases dotted physical columns and threads the quoted physical reference through expr', () => {
+    const quoteIdentifier = manifestIdentifierQuoterForConnectionType('SNOWFLAKE');
+    if (!quoteIdentifier) {
+      throw new Error('Expected a quoter for SNOWFLAKE');
+    }
+    const source = projectManifestEntry(
+      'sales',
+      {
+        table: 'analytics.sales',
+        columns: [
+          { name: 'id', type: 'string', pk: true },
+          { name: '注文.金額', type: 'number' },
+          { name: 'net.amount', type: 'number' },
+        ],
+      },
+      quoteIdentifier,
+    );
+
+    expect(source.columns.map((c) => c.name)).toEqual(['id', '注文_金額', 'net_amount']);
+    expect(source.columns[1]?.expr).toBe('"注文.金額"');
+    expect(source.columns[2]?.expr).toBe('"net.amount"');
+    expect(source.columns[0]?.expr).toBeUndefined();
+    expect(source.grain).toEqual(['id']);
+    // The projected source must satisfy the very contract that #337 tripped.
+    expect(() => toResolvedWire(source)).not.toThrow();
+  });
+
+  it('quotes the physical reference with the connection dialect identifier character', () => {
+    const mysqlQuoter = manifestIdentifierQuoterForConnectionType('MYSQL');
+    expect(mysqlQuoter?.('net.amount')).toBe('`net.amount`');
+    const postgresQuoter = manifestIdentifierQuoterForConnectionType('POSTGRESQL');
+    expect(postgresQuoter?.('net.amount')).toBe('"net.amount"');
+    // Driver-form input (local project config) resolves the same quoter.
+    expect(manifestIdentifierQuoterForConnectionType('postgres')?.('net.amount')).toBe('"net.amount"');
+    // Non-SQL connections have no dialect to quote for.
+    expect(manifestIdentifierQuoterForConnectionType('mongodb')).toBeNull();
+    expect(manifestIdentifierQuoterForConnectionType(undefined)).toBeNull();
+  });
+
+  it('keeps aliases deterministic and collision-free, and aliases dotted grain columns', () => {
+    const source = projectManifestEntry(
+      'events',
+      {
+        table: 'main.events',
+        columns: [
+          { name: 'a_b', type: 'string' },
+          { name: 'a.b', type: 'string', pk: true },
+        ],
+      },
+      manifestIdentifierQuoterForConnectionType('POSTGRESQL'),
+    );
+
+    expect(source.columns.map((c) => c.name)).toEqual(['a_b', 'a_b_2']);
+    expect(source.grain).toEqual(['a_b_2']);
+    expect(() => toResolvedWire(source)).not.toThrow();
+  });
+
+  it('aliases dotted columns without expr for non-SQL connections', () => {
+    const source = projectManifestEntry(
+      'people',
+      {
+        table: 'crm.people',
+        columns: [
+          { name: '_id', type: 'string', pk: true },
+          { name: 'address.city', type: 'string' },
+        ],
+      },
+      manifestIdentifierQuoterForConnectionType('mongodb'),
+    );
+
+    expect(source.columns.map((c) => c.name)).toEqual(['_id', 'address_city']);
+    expect(source.columns[1]?.expr).toBeUndefined();
+    expect(() => toResolvedWire(source)).not.toThrow();
   });
 });
 


### PR DESCRIPTION
Fixes #337

Makes manifest-backed sources with dotted physical column names queryable instead of hard-failing the TS/Python contract on every `sl_query`.

Warehouse column names may legally contain `.` (quoted identifiers on Postgres/Snowflake — the telemetry case had CJK names like `注文.金額` — and MongoDB field names). `projectManifestEntry` copied them verbatim into `columns[].name` and `grain`, and `toResolvedWire` then rejected the source with `ComposeContractError: must be unqualified (no '.')` — ktx generated a source it refused to query, on every request that touched it (root-cause possibility 1 from the issue).

## Approach

Manifest projection now emits contract-valid output names and keeps the physical reference in `expr`:

- A dotted physical name gets a deterministic alias (`.` → `_`, deduped against sibling columns with a numeric suffix), in `columns[].name` and `grain` both.
- The physical reference survives as the column's `expr`, quoted with the **connection dialect's identifier character** (reusing each connector's `quoteIdentifier`). The Python planner parses column `expr` in the connection's native dialect (the convention #340 enforced), so a hardcoded postgres-style quote would break backtick dialects — this is why the quoter is threaded per connection rather than hardcoded.
- The Python side needs no changes: an aliased column is exactly a computed column, an already-supported path.
- Non-SQL connections (MongoDB) alias without `expr`: their sources are searchable, and they are never SQL-queried (`assertSqlQueryableConnection` blocks that earlier).
- The authoring contract stays strict: a dot in an *agent-written* source is still rejected, because there it genuinely signals a mistaken `table.column` qualification. Only the manifest projection — where names are physical by definition — normalizes.

Plumbing: `manifestIdentifierQuoterForConnectionType` resolves the quoter from the catalog's `connectionType` (accepting both `POSTGRESQL` descriptor form and `postgres` driver form via a reverse map derived from the existing `DRIVER_TO_CONNECTION_TYPE`), cached per connection in `SemanticLayerService`; `local-sl.ts` resolves it from project config through the same `localConnectionInfoFromConfig` the catalog port uses. Sources whose connection can't be resolved project without a quoter — still searchable, and querying them fails earlier at `executeQuery`.

## Tests

- Projection regression: dotted + CJK physical columns → aliased names, dialect-quoted `expr`, aliased grain, and the projected source passes `toResolvedWire` (the exact contract #337 tripped). Fails on `main`, passes here.
- Deterministic collision handling (`a.b` alongside `a_b` → `a_b_2`), dotted pk → aliased grain.
- Quoter resolution per dialect (`"…"` postgres/snowflake, `` `…` `` mysql), driver-form input, and `null` for MongoDB/unknown.
- End-to-end check against the Python engine: a source shaped exactly like the fixed projection output (alias + quoted `expr`) compiles on both quoting families —
  postgres: `SELECT ("注文.金額") AS 注文_金額, SUM(("注文.金額")) AS total_amount FROM analytics.sales AS sales …`
  mysql: ``SELECT (`注文.金額`) AS 注文_金額, …``
- `type-check`, Biome, `dead-code` (knip default + production) pass; CLI suite has no new failures vs `main` on my machine (same pre-existing Windows environment failures noted in #352).

## Known limits (called out, not silently skipped)

- Auto-generated manifest `joins[].on` clauses would still carry a dotted key column verbatim; relationship keys with dotted names should be rare (pk/fk detection), and it's a separable follow-up.
- Two Windows-environment findings from testing, filed separately if useful: the ktx-sl YAML loader reads files with the platform default encoding (cp1252 on Windows), which fails on non-ASCII sources; and the same sqlite `EBUSY` test-cleanup issue noted in #352.
