### PR TITLE
Fix source inference for source-less aggregate measures

### DIFF
--- a/python/ktx-sl/semantic_layer/planner.py
+++ b/python/ktx-sl/semantic_layer/planner.py
@@ -60,7 +60,7 @@ class QueryPlanner:
         dimensions = self._resolve_dimensions(query.dimensions)
 
         # 2. Resolve measures (parse, look up pre-defined, classify)
-        raw_measures = self._resolve_measures(query.measures)
+        raw_measures = self._resolve_measures(query.measures, dimensions)
 
         if query.predefined_measures_only:
             self._reject_composed_measures(raw_measures)
@@ -212,7 +212,11 @@ class QueryPlanner:
             )
         return field  # not found — leave as-is, downstream will error
 
-    def _resolve_measures(self, raw: list[str | dict]) -> list[ResolvedMeasure]:
+    def _resolve_measures(
+        self,
+        raw: list[str | dict],
+        dimensions: list[QueryDimension],
+    ) -> list[ResolvedMeasure]:
         measures: list[ResolvedMeasure] = []
         # Collect all named measures for dependency detection
         named: set[str] = set()
@@ -221,10 +225,26 @@ class QueryPlanner:
                 named.add(m["name"])
         colliding_predefined_names = self._collect_colliding_predefined_names(raw)
 
+        # Collect candidate sources from dimensions and other measures in the query
+        candidate_sources: set[str] = set()
+        for d in dimensions:
+            candidate_sources.update(self.parser.extract_source_refs(d.field))
+
+        for m in raw:
+            candidate_sources.update(
+                self._extract_sources_from_raw_measure(
+                    m, colliding_predefined_names, named
+                )
+            )
+
         for m in raw:
             if isinstance(m, str):
                 measures.append(
-                    self._resolve_measure_str(m, colliding_predefined_names)
+                    self._resolve_measure_str(
+                        m,
+                        colliding_predefined_names,
+                        candidate_sources=candidate_sources,
+                    )
                 )
             elif isinstance(m, dict):
                 measures.append(
@@ -232,6 +252,7 @@ class QueryPlanner:
                         m,
                         named,
                         colliding_predefined_names,
+                        candidate_sources=candidate_sources,
                     )
                 )
 
@@ -570,6 +591,7 @@ class QueryPlanner:
         self,
         s: str,
         colliding_predefined_names: set[str],
+        candidate_sources: set[str] | None = None,
     ) -> ResolvedMeasure:
         """
         "orders.revenue" → pre-defined lookup
@@ -601,7 +623,7 @@ class QueryPlanner:
                         qualified,
                     )
                     return self._resolve_measure_str(
-                        qualified, colliding_predefined_names
+                        qualified, colliding_predefined_names, candidate_sources
                     )
 
         if predefined_ref:
@@ -639,13 +661,21 @@ class QueryPlanner:
             raise ValueError(f"Measure '{s}' does not reference any source")
 
         # Runtime expression
+        inferred_source = None
         if not parsed.source_refs:
-            raise ValueError(f"Measure '{s}' does not reference any source")
+            if candidate_sources and len(candidate_sources) == 1:
+                inferred_source = next(iter(candidate_sources))
+                s = self._qualify_bare_columns(s, inferred_source)
+                parsed = self.parser.parse(s)
+            else:
+                self._raise_sourceless_measure_error(s, candidate_sources)
 
         # Reject nested aggregation (e.g., avg(sum(orders.amount)))
         self._check_nested_aggregation(s)
 
-        source_name = sorted(parsed.source_refs)[0]
+        source_name = (
+            inferred_source if inferred_source else sorted(parsed.source_refs)[0]
+        )
         name = self._auto_measure_name(s)
         return ResolvedMeasure(
             name=name,
@@ -660,6 +690,7 @@ class QueryPlanner:
         d: dict,
         named: set[str],
         colliding_predefined_names: set[str],
+        candidate_sources: set[str] | None = None,
     ) -> ResolvedMeasure:
         expr = d.get("expr", "")
         name = d.get("name", expr)
@@ -720,13 +751,24 @@ class QueryPlanner:
                 depends_on=sorted(all_dep_names),
             )
 
+        inferred_source = None
         if not parsed.source_refs:
-            raise ValueError(f"Measure expr '{expr}' does not reference any source")
+            if parsed.is_aggregate:
+                if candidate_sources and len(candidate_sources) == 1:
+                    inferred_source = next(iter(candidate_sources))
+                    expr = self._qualify_bare_columns(expr, inferred_source)
+                    parsed = self.parser.parse(expr, known_measure_names=named)
+                else:
+                    self._raise_sourceless_measure_error(expr, candidate_sources)
+            else:
+                raise ValueError(f"Measure expr '{expr}' does not reference any source")
 
         # Reject nested aggregation (e.g., avg(sum(orders.amount)))
         self._check_nested_aggregation(expr)
 
-        source_name = sorted(parsed.source_refs)[0]
+        source_name = (
+            inferred_source if inferred_source else sorted(parsed.source_refs)[0]
+        )
         return ResolvedMeasure(
             name=name,
             original_name=name,
@@ -734,6 +776,94 @@ class QueryPlanner:
             source_name=source_name,
             provenance=Provenance.COMPOSED,
         )
+
+    def _extract_sources_from_raw_measure(
+        self,
+        m: str | dict,
+        colliding_predefined_names: set[str],
+        known_measure_names: set[str],
+    ) -> set[str]:
+        sources = set()
+        if isinstance(m, str):
+            predefined_ref = self._match_predefined_ref(m)
+            if predefined_ref:
+                sources.add(predefined_ref[0])
+                return sources
+
+            # Try unqualified resolution for bare identifiers (e.g. "revenue" → "orders.revenue")
+            parsed = self.parser.parse(m)
+            if not parsed.is_aggregate:
+                bare = m.strip()
+                if bare.isidentifier():
+                    unqualified = self._resolve_unqualified_measure(bare)
+                    if unqualified:
+                        sources.add(unqualified[0])
+                        return sources
+
+            if parsed.source_refs:
+                sources.update(parsed.source_refs)
+        elif isinstance(m, dict):
+            expr = m.get("expr", "")
+            parsed = self.parser.parse(expr, known_measure_names=known_measure_names)
+            for src_name, _ in self._extract_predefined_refs(expr):
+                sources.add(src_name)
+            if parsed.source_refs:
+                sources.update(parsed.source_refs)
+        return sources
+
+    def _qualify_bare_columns(self, expr: str, source_name: str) -> str:
+        """Qualify bare column references in an aggregate expression with the inferred source name."""
+        try:
+            quoted = quote_reserved_identifiers(expr, self.dialect)
+            tree = sqlglot.parse_one(f"SELECT {quoted}", read=self.dialect)
+
+            def _qualify(node: exp.Expression) -> exp.Expression:
+                if isinstance(node, exp.Column) and not node.table:
+                    return exp.Column(
+                        this=node.this.copy(),
+                        table=exp.to_identifier(source_name),
+                    )
+                return node
+
+            transformed = tree.transform(_qualify)
+            return transformed.expressions[0].sql(dialect=self.dialect)
+        except Exception as e:
+            logger.debug(
+                "Failed to qualify bare columns in expression '%s' for source '%s': %s",
+                expr,
+                source_name,
+                e,
+            )
+            return expr
+
+    def _raise_sourceless_measure_error(
+        self, expr: str, candidate_sources: set[str] | None
+    ) -> None:
+        candidate_sources = candidate_sources or set()
+        if candidate_sources:
+            src_list = sorted(list(candidate_sources))
+            msg_prefix = f"is ambiguous. The query references multiple sources: {', '.join(src_list)}"
+        else:
+            src_list = sorted(list(self.sources.keys()))
+            msg_prefix = "does not reference any source"
+            if src_list:
+                msg_prefix += f". The model has multiple sources: {', '.join(src_list)}"
+            else:
+                msg_prefix += ". The model has no sources defined"
+
+        suggestions = []
+        for src_name in src_list:
+            source = self.sources.get(src_name)
+            if source:
+                pk_col = source.grain[0] if source.grain else "id"
+                suggestions.append(f"count({src_name}.{pk_col})")
+                for mdef in source.measures[:2]:
+                    suggestions.append(f"{src_name}.{mdef.name}")
+
+        msg = f"Measure expr '{expr}' {msg_prefix}."
+        if suggestions:
+            msg += f" Suggest using one of: {', '.join(suggestions)}"
+        raise ValueError(msg)
 
     def _check_nested_aggregation(self, expr: str) -> None:
         """Reject expressions with nested aggregate functions (e.g., avg(sum(x)))."""

--- a/python/ktx-sl/tests/test_coverage_gaps.py
+++ b/python/ktx-sl/tests/test_coverage_gaps.py
@@ -669,7 +669,6 @@ class TestMeasureNoSourceRef:
             planner.plan(
                 SemanticQuery(
                     measures=["sum(1)"],
-                    dimensions=["orders.status"],
                 )
             )
 

--- a/python/ktx-sl/tests/test_planner.py
+++ b/python/ktx-sl/tests/test_planner.py
@@ -1507,3 +1507,123 @@ def test_derived_measure_with_bigquery_native_dependency(make_engine_factory):
     assert "APPROX_COUNT_DISTINCT" in result.sql.upper(), (
         f"APPROX_COUNT_DISTINCT was rewritten away:\n{result.sql}"
     )
+
+
+class TestSourcelessAggregates:
+    def test_count_star_unambiguous(self, planner):
+        query = SemanticQuery(
+            measures=["count(*)"],
+            dimensions=["orders.status"],
+        )
+        plan = planner.plan(query)
+        assert "orders" in plan.sources_used
+        assert len(plan.measures) == 1
+        assert plan.measures[0].source_name == "orders"
+        assert "count" in plan.measures[0].expr.lower()
+
+    def test_count_one_unambiguous(self, planner):
+        query = SemanticQuery(
+            measures=["count(1)"],
+            dimensions=["orders.status"],
+        )
+        plan = planner.plan(query)
+        assert "orders" in plan.sources_used
+        assert len(plan.measures) == 1
+        assert plan.measures[0].source_name == "orders"
+        assert "count" in plan.measures[0].expr.lower()
+
+    def test_sum_amount_unambiguous(self, planner):
+        query = SemanticQuery(
+            measures=["sum(amount)"],
+            dimensions=["orders.status"],
+        )
+        plan = planner.plan(query)
+        assert "orders" in plan.sources_used
+        assert len(plan.measures) == 1
+        assert plan.measures[0].source_name == "orders"
+        assert "sum" in plan.measures[0].expr.lower()
+        assert "orders.amount" in plan.measures[0].expr.lower()
+
+    def test_mixed_measures_unambiguous(self, planner):
+        query = SemanticQuery(
+            measures=["sum(amount)", "count(*)"],
+            dimensions=["orders.status"],
+        )
+        plan = planner.plan(query)
+        assert "orders" in plan.sources_used
+        assert len(plan.measures) == 2
+        assert all(m.source_name == "orders" for m in plan.measures)
+        exprs_lower = {m.expr.lower() for m in plan.measures}
+        assert any("orders.amount" in e for e in exprs_lower)
+        assert any("count" in e for e in exprs_lower)
+
+    def test_unambiguous_via_other_measures(self, planner):
+        query = SemanticQuery(
+            measures=["count(*)", "sum(orders.amount)"],
+        )
+        plan = planner.plan(query)
+        assert "orders" in plan.sources_used
+        assert len(plan.measures) == 2
+        assert all(m.source_name == "orders" for m in plan.measures)
+
+    def test_measure_only_infer_via_other_qualified_measure(self, planner):
+        query = SemanticQuery(
+            measures=["sum(amount)", "count(orders.id)"],
+        )
+        plan = planner.plan(query)
+        assert "orders" in plan.sources_used
+        assert len(plan.measures) == 2
+        assert all(m.source_name == "orders" for m in plan.measures)
+        exprs_lower = {m.expr.lower() for m in plan.measures}
+        assert any("orders.amount" in e for e in exprs_lower)
+        assert any("orders.id" in e for e in exprs_lower)
+
+    def test_unambiguous_dict_format(self, planner):
+        query = SemanticQuery(
+            measures=[{"expr": "sum(amount)", "name": "total_amount"}],
+            dimensions=["orders.status"],
+        )
+        plan = planner.plan(query)
+        assert "orders" in plan.sources_used
+        assert len(plan.measures) == 1
+        assert plan.measures[0].source_name == "orders"
+        assert "sum" in plan.measures[0].expr.lower()
+        assert "orders.amount" in plan.measures[0].expr.lower()
+
+    def test_unambiguous_dict_format_count_star(self, planner):
+        query = SemanticQuery(
+            measures=[{"expr": "count(*)", "name": "total_count"}],
+            dimensions=["orders.status"],
+        )
+        plan = planner.plan(query)
+        assert "orders" in plan.sources_used
+        assert len(plan.measures) == 1
+        assert plan.measures[0].source_name == "orders"
+        assert "count" in plan.measures[0].expr.lower()
+
+    def test_ambiguous_raises(self, planner):
+        query = SemanticQuery(
+            measures=["count(*)"],
+            dimensions=["orders.status", "customers.segment"],
+        )
+        with pytest.raises(ValueError) as exc:
+            planner.plan(query)
+        err_msg = str(exc.value).lower()
+        assert "ambiguous" in err_msg
+        assert "customers" in err_msg
+        assert "orders" in err_msg
+        assert "count(customers.id)" in err_msg
+        assert "count(orders.id)" in err_msg
+
+    def test_zero_sources_raises(self, planner):
+        query = SemanticQuery(
+            measures=["count(*)"],
+        )
+        with pytest.raises(ValueError) as exc:
+            planner.plan(query)
+        err_msg = str(exc.value).lower()
+        assert "does not reference any source" in err_msg
+        assert "customers" in err_msg
+        assert "orders" in err_msg
+        assert "count(customers.id)" in err_msg
+        assert "count(orders.id)" in err_msg


### PR DESCRIPTION
Fixes #336

## Summary

This PR adds source inference for source-less aggregate expressions in the semantic layer.

Previously, aggregate expressions without an explicit `source.column` reference (for example `count(*)`, `count(1)`, and `sum(amount)`) were rejected because no source could be inferred.

This change infers the source when the query already determines a single unambiguous source through its dimensions and/or other measures. Queries that remain ambiguous or have no inferable source continue to raise an error with improved guidance.

## Changes

- Infer the source for source-less aggregate expressions when exactly one source can be determined.
- Preserve existing rejection behavior for ambiguous and zero-source queries.
- Improve error messages by:
  - listing candidate sources
  - suggesting `count(source.pk)` alternatives
- Add unit tests covering:
  - `count(*)`
  - `count(1)`
  - bare-column aggregates (`sum(amount)`)
  - dimension-only inference
  - measure-only inference
  - mixed queries
  - dictionary measure definitions
  - ambiguous multi-source queries
  - zero-source queries

## Testing

- Ran the semantic layer test suite.
- Added unit tests covering both successful inference and expected failure scenarios.